### PR TITLE
fix: add ownership checks in analytics controller

### DIFF
--- a/worker/database/database.ts
+++ b/worker/database/database.ts
@@ -34,8 +34,10 @@ export type {
  * Provides database connection, shared utilities, and core operations.
  * Domain-specific operations are handled by dedicated service classes.
  */
+export type DB = ReturnType<typeof drizzle<typeof schema>>;
+
 export class DatabaseService {
-    public readonly db: ReturnType<typeof drizzle>;
+    public readonly db: DB;
 
     constructor(env: DatabaseEnv) {
         const instrumented = Sentry.instrumentD1WithSentry(env.DB);


### PR DESCRIPTION
Currently, a user can view the analytics for other users. They can also query analytics for apps that are not owner by them.

This MR adds checks to make sure that the user can only view their own apps analytics.