### PR TITLE
fix: copy URL button was not working

### DIFF
--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -246,7 +246,7 @@ export default function AppView() {
 			// 	errorMessage: 'Failed to remix app',
 			// },
 		}),
-		[app, navigate],
+		[app],
 	);
 
 	// Reusable authenticated action handler
@@ -368,9 +368,9 @@ export default function AppView() {
 	]);
 
 	const handleCopyUrl = () => {
-		if (!app?.cloudflareUrl) return;
+		if (!appUrl) return;
 
-		navigator.clipboard.writeText(app.cloudflareUrl);
+		navigator.clipboard.writeText(appUrl);
 		setCopySuccess(true);
 		setTimeout(() => setCopySuccess(false), 2000);
 	};


### PR DESCRIPTION
The "Copy" button next to the "Live Preview" heading was not working.

This PR fixes the link that is supposed to be copied.

There is also an unnecessary dependency in the `useMemo`, that has been removed.

<img width="514" height="154" alt="image" src="https://github.com/user-attachments/assets/458f2d60-12f2-4d1d-bac8-6f8b2562071d" />
