### PR TITLE
Fix: Return correct csrf validation error format

### DIFF
--- a/worker/app.ts
+++ b/worker/app.ts
@@ -60,8 +60,10 @@ export function createApp(env: Env): Hono<AppEnv> {
         } catch (error) {
             if (error instanceof SecurityError && error.type === SecurityErrorType.CSRF_VIOLATION) {
                 return new Response(JSON.stringify({ 
-                    error: 'CSRF validation failed',
-                    code: 'CSRF_VIOLATION'
+                    error: { 
+                        message: 'CSRF validation failed',
+                        type: SecurityErrorType.CSRF_VIOLATION
+                    }
                 }), {
                     status: 403,
                     headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
This wrong format was causing anyone with fresh deployment and with no oauth to experience issues logging in or making apps without refreshing.