### PR TITLE
Feat: use api-proxy for user app uptime check instead of direct call

### DIFF
--- a/worker/api/routes/index.ts
+++ b/worker/api/routes/index.ts
@@ -10,6 +10,7 @@ import { setupGitHubExporterRoutes } from './githubExporterRoutes';
 import { setupCodegenRoutes } from './codegenRoutes';
 import { setupScreenshotRoutes } from './imagesRoutes';
 import { setupSentryRoutes } from './sentryRoutes';
+import { setupPreviewProxyRoutes } from './previewProxyRoutes';
 import { Hono } from "hono";
 import { AppEnv } from "../../types/appenv";
 import { setupStatusRoutes } from './statusRoutes';
@@ -58,4 +59,7 @@ export function setupRoutes(app: Hono<AppEnv>): void {
 
     // Screenshot serving routes (public)
     setupScreenshotRoutes(app);
+
+    // Preview proxy routes
+    setupPreviewProxyRoutes(app);
 }

--- a/worker/api/routes/previewProxyRoutes.ts
+++ b/worker/api/routes/previewProxyRoutes.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono';
+import { AppEnv } from '../../types/appenv';
+import { AuthConfig, setAuthLevel } from '../../middleware/auth/routeAuth';
+import { resolvePreview } from '../../utils/previewResolver';
+import { buildUserWorkerUrl } from '../../utils/urls';
+
+/**
+ * Preview status routes - check if an app preview is available
+ * This directly checks sandbox/dispatcher without needing to access subdomain URLs
+ */
+export function setupPreviewProxyRoutes(app: Hono<AppEnv>): void {
+    // Check preview availability for an app (HEAD request only)
+    app.on('HEAD', '/api/apps/:id/preview-status', setAuthLevel(AuthConfig.public), async (c) => {
+        const env = c.env;
+        const appId = c.req.param('id');
+
+        try {
+            // Create a clean, isolated HEAD request for testing
+            // This ensures no user cookies or sensitive headers are forwarded
+            const testUrl = buildUserWorkerUrl(env, appId);
+            const cleanRequest = new Request(testUrl, {
+                method: 'HEAD',
+            });
+            
+            const result = await resolvePreview(appId, cleanRequest, env);
+            
+            if (!result.available) {
+                return new Response(null, { status: 404 });
+            }
+            
+            // Return success with preview type header
+            const headers = new Headers();
+            if (result.type) {
+                headers.set('X-Preview-Type', result.type);
+                headers.set('Access-Control-Expose-Headers', 'X-Preview-Type');
+            }
+            
+            return new Response(null, { status: 200, headers });
+        } catch (error: unknown) {
+            const err = error as Error;
+            console.error('Preview status check error:', err);
+            return new Response(null, { status: 500 });
+        }
+    });
+}

--- a/worker/utils/previewResolver.ts
+++ b/worker/utils/previewResolver.ts
@@ -1,0 +1,72 @@
+import { proxyToSandbox } from '../services/sandbox/request-handler';
+import { isDispatcherAvailable } from './dispatcherUtils';
+import { createLogger } from '../logger';
+
+const logger = createLogger('PreviewResolver');
+
+export type PreviewType = 'sandbox' | 'sandbox-error' | 'dispatcher';
+
+export interface PreviewResult {
+    available: boolean;
+    type?: PreviewType;
+    response?: Response;
+    error?: string;
+}
+
+/**
+ * Resolve preview availability for an app by checking sandbox and dispatcher
+ * @param appId - The app identifier (subdomain)
+ * @param request - The incoming request
+ * @param env - Worker environment
+ * @returns PreviewResult with availability status and response
+ */
+export async function resolvePreview(
+    appId: string,
+    request: Request,
+    env: Env
+): Promise<PreviewResult> {
+    // Try sandbox first
+    const sandboxResponse = await proxyToSandbox(request, env);
+    if (sandboxResponse) {
+        logger.info(`Preview available in sandbox for: ${appId}`);
+        
+        const type: PreviewType = sandboxResponse.status === 500 ? 'sandbox-error' : 'sandbox';
+        
+        return {
+            available: sandboxResponse.status !== 500,
+            type,
+            response: sandboxResponse,
+        };
+    }
+
+    // Try dispatcher (deployed worker)
+    logger.info(`Sandbox miss for ${appId}, attempting dispatch to permanent worker`);
+    if (!isDispatcherAvailable(env)) {
+        logger.warn(`Dispatcher not available, cannot serve: ${appId}`);
+        return {
+            available: false,
+            error: 'This application is not currently available.',
+        };
+    }
+
+    try {
+        const dispatcher = env['DISPATCHER'];
+        const worker = dispatcher.get(appId);
+        const dispatcherResponse = await worker.fetch(request);
+
+        logger.info(`Preview available in dispatcher for: ${appId}`);
+        
+        return {
+            available: dispatcherResponse.ok,
+            type: 'dispatcher',
+            response: dispatcherResponse,
+        };
+    } catch (error: unknown) {
+        const err = error as Error;
+        logger.warn(`Error dispatching to worker '${appId}': ${err.message}`);
+        return {
+            available: false,
+            error: 'An error occurred while loading this application.',
+        };
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses issues with Cloudflare Zero Trust access for preview iframes by routing availability checks through the main application proxy instead of direct subdomain calls.

## Changes
- **New API endpoint**: Added `/api/apps/:id/preview-status` (public, HEAD only) that checks preview availability through the proxy
- **Refactored preview resolution**: Created `worker/utils/previewResolver.ts` to centralize preview availability logic (sandbox → dispatcher fallback)
- **Simplified main worker**: Refactored `worker/index.ts` to delegate preview resolution to shared utility
- **Updated frontend**: Modified `preview-iframe.tsx` to use new proxy endpoint instead of direct subdomain HEAD requests

## Motivation
Users with Cloudflare Zero Trust policies configured were unable to load preview iframes because the availability check attempted to access user app subdomains directly, which Zero Trust policies blocked. By routing the check through the main application proxy (which users are already authenticated to), the preview availability check bypasses Zero Trust restrictions.

## Testing
- Verify preview availability checks work for apps in sandbox
- Verify preview availability checks work for deployed (dispatcher) apps
- Confirm Zero Trust users can now see preview iframes
- Ensure existing preview functionality remains intact

## Related Issues
This may help with preview loading issues mentioned in:
- #195 (Surface log stream from sandboxed app)

---

<sub>**This PR description was automatically generated by [Claude Code](https://claude.ai)**</sub>
