### PR TITLE
Fixing the issue where `npm run setup` is not working on a Windows sy…

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,7 +11,7 @@ Local first time setup guide for VibSDK - get your AI coding platform running lo
 Before getting started, make sure you have:
 
 ### Required
-- **Node.js** (v18 or later)
+- **Node.js** (v22 or later)
 - **Cloudflare account** with API access  
 - **Cloudflare API Token** with appropriate permissions
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -2113,7 +2113,12 @@ async function main() {
 	await setup.setup();
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run if this is the main module (supports both direct execution and tsx)
+const isMainModule = import.meta.url.endsWith('setup.ts') ||
+	import.meta.url === `file://${process.argv[1]}` ||
+	process.argv[1]?.endsWith('setup.ts');
+
+if (isMainModule) {
 	main().catch((error) => {
 		console.error('Setup failed:', error);
 		process.exit(1);


### PR DESCRIPTION
On a Windows system, running `npm run setup` locally was unresponsive; it worked normally after a repair.
<img width="600" height="619" alt="image" src="https://github.com/user-attachments/assets/69e48cfd-96d4-4f5d-a30d-01376ca99e79" />