### PR TITLE
fix: added instructions for token creation

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -2,6 +2,12 @@
 #CUSTOM_DOMAIN="your-domain.com" # Your custom domain for CORS
 #ENVIRONMENT="prod" # Options: dev, staging, prod
 
+# Cloudflare Credentials (Required for manual deployment via `bun run deploy`)
+# These are automatically provided when using "Deploy to Cloudflare" button
+# Get these from: https://dash.cloudflare.com/profile/api-tokens
+#CLOUDFLARE_API_TOKEN="" # API token with Account-level permissions (see README for required permissions)
+#CLOUDFLARE_ACCOUNT_ID="" # Your Cloudflare account ID
+
 # Essential Secrets:
 #CLOUDFLARE_AI_GATEWAY_TOKEN="" # If this has read and edit permissions, the AI Gateway will be created automatically. run is required at the least
 

--- a/README.md
+++ b/README.md
@@ -332,11 +332,52 @@ The setup script will guide you through:
 
 After setup, start the development server:
 
+#### Required for Manual Deployment
+
+If you're deploying manually using `bun run deploy`, you **must** set these environment variables:
+
+**Cloudflare API Token & Account ID:**
+
+1. **Get your Account ID**:
+   - Go to [Cloudflare Dashboard -> Workers and Pages](https://dash.cloudflare.com/?to=/:account/workers-and-pages)
+   - Copy your Account ID from the right sidebar or URL
+
+2. **Create an API Token**:
+   - Go to [Cloudflare Dashboard -> API Tokens](https://dash.cloudflare.com/?to=/:account/api-tokens)
+   - Click "Create Token" → Use custom token
+   - Configure with these **minimum required permissions**:
+     - **Account** → **Containers** → **Edit**
+     - **Account** → **Secrets Store** → **Edit**
+     - **Account** → **D1** → **Edit**
+     - **Account** → **Workers R2 Storage** → **Edit**
+     - **Account** → **Workers KV Storage** → **Edit**
+     - **Account** → **Workers Scripts** → **Edit**
+     - **Account** → **Account Settings** → **Read**
+     - **Zone** → **Workers Routes** → **Edit**
+   - Under "Zone Resources": Select "All zones from an account" → Choose your account
+   - Click "Continue to summary" → "Create Token"
+   - Copy the token immediately (you won't see it again)
+
+3. **Set the environment variables**:
+   ```bash
+   export CLOUDFLARE_API_TOKEN="your-api-token-here"
+   export CLOUDFLARE_ACCOUNT_ID="your-account-id-here"
+   ```
+
+> **Note**: These credentials are automatically provided when using the "Deploy to Cloudflare" button, but are required for manual `bun run deploy`.
+
+**For Local Development (.dev.vars):**
 ```bash
 bun run dev
 ```
 
 Visit `http://localhost:5173` to access VibSDK locally.
+
+**For Production Deployment (.prod.vars):**
+```bash
+cp .dev.vars.example .prod.vars
+# Edit .prod.vars with your production API keys and tokens
+```
 
 ### Production Deployment
 


### PR DESCRIPTION
The README was missing instructions for setting up the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` which was essential for running the `bun run deploy` script.