### PR TITLE
feat: add query length validation with 20k character limit

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -203,6 +203,7 @@ export type {
 
 export type { RateLimitError } from "worker/services/rate-limit/errors";
 export type { AgentPreviewResponse, CodeGenArgs } from 'worker/api/controllers/agent/types';
+export { MAX_AGENT_QUERY_LENGTH } from 'worker/api/controllers/agent/types';
 export type { RateLimitErrorResponse } from 'worker/api/responses';
 export { RateLimitExceededError, SecurityError, SecurityErrorType } from '../shared/types/errors.js';
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -592,11 +592,16 @@ class ApiClient {
 
 	async createAgentSession(args: CodeGenArgs): Promise<AgentStreamingResponse> {
 		try {
-			const { response, data } = await this.requestRaw('/api/agent', {
-				method: 'POST',
-				body: args,
-				skipJsonParsing: true, // Don't parse JSON for streaming response
-			});
+			const { response, data } = await this.requestRaw(
+				'/api/agent',
+				{
+					method: 'POST',
+					body: args,
+					skipJsonParsing: true, // Don't parse JSON for streaming response
+				},
+				false,
+				true,
+			);
 			
 			// Check if response is ok
 			if (!response.ok) {

--- a/src/routes/chat/hooks/use-chat.ts
+++ b/src/routes/chat/hooks/use-chat.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
     RateLimitExceededError,
+	MAX_AGENT_QUERY_LENGTH,
 	type BlueprintType,
 	type WebSocketMessage,
 	type CodeFixEdits,
@@ -444,6 +445,13 @@ export function useChat({
 						const errorMsg = 'Please enter a description of what you want to build';
 						logger.error('Query is required for new code generation');
 						toast.error(errorMsg);
+						return;
+					}
+
+					if (userQuery.length > MAX_AGENT_QUERY_LENGTH) {
+						const errorMsg = `Prompt too large (${userQuery.length} characters). Maximum allowed is ${MAX_AGENT_QUERY_LENGTH} characters.`;
+						toast.error(errorMsg);
+						setMessages(() => [createAIMessage('main', errorMsg)]);
 						return;
 					}
 

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -3,7 +3,7 @@ import { ArrowRight, Info } from 'react-feather';
 import { useNavigate } from 'react-router';
 import { useAuth } from '@/contexts/auth-context';
 import { ProjectModeSelector, type ProjectModeOption } from '../components/project-mode-selector';
-import type { ProjectType } from '@/api-types';
+import { MAX_AGENT_QUERY_LENGTH, SUPPORTED_IMAGE_MIME_TYPES, type ProjectType } from '@/api-types';
 import { useFeature } from '@/features';
 import { useAuthGuard } from '../hooks/useAuthGuard';
 import { usePaginatedApps } from '@/hooks/use-paginated-apps';
@@ -14,7 +14,6 @@ import { useImageUpload } from '@/hooks/use-image-upload';
 import { useDragDrop } from '@/hooks/use-drag-drop';
 import { ImageUploadButton } from '@/components/image-upload-button';
 import { ImageAttachmentPreview } from '@/components/image-attachment-preview';
-import { SUPPORTED_IMAGE_MIME_TYPES } from '@/api-types';
 import { toast } from 'sonner';
 
 export default function Home() {
@@ -89,6 +88,13 @@ export default function Home() {
 	const discoverReady = useMemo(() => !loading && (apps?.length ?? 0) > 5, [loading, apps]);
 
 	const handleCreateApp = (query: string, mode: ProjectType) => {
+		if (query.length > MAX_AGENT_QUERY_LENGTH) {
+			toast.error(
+				`Prompt too large (${query.length} characters). Maximum allowed is ${MAX_AGENT_QUERY_LENGTH} characters.`,
+			);
+			return;
+		}
+
 		const encodedQuery = encodeURIComponent(query);
 		const encodedMode = encodeURIComponent(mode);
 

--- a/worker/agents/core/stateMigration.ts
+++ b/worker/agents/core/stateMigration.ts
@@ -3,6 +3,7 @@ import { StructuredLogger } from '../../logger';
 import { TemplateDetails } from 'worker/services/sandbox/sandboxTypes';
 import { generateNanoId } from '../../utils/idGenerator';
 import { generateProjectName } from '../utils/templateCustomizer';
+import { MAX_AGENT_QUERY_LENGTH } from 'worker/api/controllers/agent/types';
 
 // Type guards for legacy state detection
 type LegacyFileFormat = {
@@ -38,6 +39,14 @@ export class StateMigration {
     static migrateIfNeeded(state: AgentState, logger: StructuredLogger): AgentState | null {
         let needsMigration = false;
         
+
+        // If the query is too long, truncate it to avoid performance issues
+        if (state.query && state.query.length > MAX_AGENT_QUERY_LENGTH) {
+            logger.warn("Large prompt detected. Truncating query to avoid performance issues");
+            state.query = state.query.slice(0, MAX_AGENT_QUERY_LENGTH);
+            needsMigration = true;
+        }
+
         //------------------------------------------------------------------------------------
         // Migrate files from old schema
         //------------------------------------------------------------------------------------

--- a/worker/api/controllers/agent/types.ts
+++ b/worker/api/controllers/agent/types.ts
@@ -2,6 +2,8 @@ import type { PreviewType } from "../../../services/sandbox/sandboxTypes";
 import type { ImageAttachment } from '../../../types/image-attachment';
 import type { BehaviorType, ProjectType } from '../../../agents/core/types';
 
+export const MAX_AGENT_QUERY_LENGTH = 20_000;
+
 export interface CodeGenArgs {
     query: string;
     language?: string;


### PR DESCRIPTION
## Summary
Add query length validation with a 20,000 character limit to prevent performance issues from extremely large prompts. Validation is applied on both client and server sides for defense-in-depth.

## Changes
- Add `MAX_AGENT_QUERY_LENGTH` constant (20,000 characters) in `worker/api/controllers/agent/types.ts`
- Add server-side validation in `CodingAgentController` returning 413 error with `SecurityError` for oversized queries
- Add client-side validation in `src/routes/home.tsx` and `src/routes/chat/hooks/use-chat.ts` with user-friendly toast messages
- Truncate oversized queries during state migration to prevent performance issues with existing sessions
- Export `MAX_AGENT_QUERY_LENGTH` from `src/api-types.ts` for frontend usage
- Suppress toast notifications in `createAgentSession` API to avoid duplicate error messages (client validates first)

## Motivation
Large queries can cause performance degradation and excessive resource consumption during code generation. This change enforces a reasonable limit to protect the system while providing clear feedback to users.

## Testing
- Manually test submitting prompts exceeding 20k characters on home page and chat page
- Verify 413 error response from API when bypassing client validation
- Verify existing sessions with large queries are handled gracefully during state migration

## Breaking Changes
None - this is a new validation that protects against edge cases. Existing normal usage is unaffected.