### PR TITLE
refactor: restructure inference context to separate metadata from runtime state

### DIFF
--- a/worker/agents/assistants/realtimeCodeFixer.ts
+++ b/worker/agents/assistants/realtimeCodeFixer.ts
@@ -490,7 +490,7 @@ ${block.error}
             
             const llmResponse = await infer({
                 env: this.env,
-                metadata: this.inferenceContext,
+                metadata: this.inferenceContext.metadata,
                 modelName: AGENT_CONFIG['realtimeCodeFixer'].name,
                 reasoning_effort: 'low',
                 temperature: 0.0,

--- a/worker/agents/core/behaviors/agentic.ts
+++ b/worker/agents/core/behaviors/agentic.ts
@@ -88,7 +88,7 @@ export class AgenticCodingBehavior extends BaseCodingBehavior<AgenticState> impl
             lastPackageJson: packageJson,
             sessionId: sandboxSessionId!,
             hostname,
-            inferenceContext,
+            metadata: inferenceContext.metadata,
             projectType: this.projectType,
             behaviorType: 'agentic'
         });

--- a/worker/agents/core/behaviors/phasic.ts
+++ b/worker/agents/core/behaviors/phasic.ts
@@ -114,7 +114,7 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
             lastPackageJson: packageJson,
             sessionId: sandboxSessionId!,
             hostname,
-            inferenceContext,
+            metadata: inferenceContext.metadata,
             projectType: this.projectType,
             behaviorType: 'phasic'
         };
@@ -159,7 +159,7 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
     }
 
     migrateStateIfNeeded(): void {
-        const migratedState = StateMigration.migrateIfNeeded(this.state, this.logger) as PhasicState | null;
+        const migratedState = StateMigration.migratePhasic(this.state, this.logger) as PhasicState | null;
         if (migratedState) {
             this.setState(migratedState);
         }
@@ -587,7 +587,7 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
                     });
                 },
                 userContext,
-                shouldAutoFix: this.state.inferenceContext.enableRealtimeCodeFix,
+                shouldAutoFix: this.getInferenceContext().enableRealtimeCodeFix,
                 fileChunkGeneratedCallback: streamChunks ? (filePath: string, chunk: string, format: 'full_content' | 'unified_diff') => {
                     this.broadcast(WebSocketMessageResponses.FILE_CHUNK_GENERATED, {
                         message: `Generating file: ${filePath}`,
@@ -627,7 +627,7 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
             ? await runPreDeploySafetyGate({
                   files: finalFiles,
                   env: this.env,
-                  inferenceContext: this.state.inferenceContext,
+                  inferenceContext: this.getInferenceContext(),
                   query: this.state.query,
                   template: templateDetails,
                   phase,
@@ -647,7 +647,7 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
             await this.deployToSandbox(safeFiles, false, phase.name, true);
             if (postPhaseFixing) {
                 await this.applyDeterministicCodeFixes();
-                if (this.state.inferenceContext.enableFastSmartCodeFix) {
+                if (this.getInferenceContext().enableFastSmartCodeFix) {
                     await this.applyFastSmartCodeFixes();
                 }
             }

--- a/worker/agents/core/state.ts
+++ b/worker/agents/core/state.ts
@@ -2,7 +2,7 @@ import type { PhasicBlueprint, AgenticBlueprint, PhaseConceptType ,
     FileOutputType,
     Blueprint,
 } from '../schemas';
-import type { InferenceContext } from '../inferutils/config.types';
+import type { InferenceMetadata } from '../inferutils/config.types';
 import { BehaviorType, Plan, ProjectType } from './types';
 
 export interface FileState extends FileOutputType {
@@ -45,7 +45,7 @@ export interface BaseProjectState {
     templateName: string | 'custom';
     
     // Inference context
-    inferenceContext: InferenceContext;
+    readonly metadata: InferenceMetadata;
     
     // Generation control
     shouldBeGenerating: boolean;

--- a/worker/agents/inferutils/infer.ts
+++ b/worker/agents/inferutils/infer.ts
@@ -85,7 +85,7 @@ export async function executeInference<T extends z.AnyZodObject>(   {
     if (modelConfig) {
         // Use explicitly provided model config
         conf = modelConfig;
-    } else if (context?.userId && context?.userModelConfigs) {
+    } else if (context?.metadata.userId && context?.userModelConfigs) {
         // Try to get user-specific configuration from context cache
         conf = context.userModelConfigs[agentActionName];
         if (conf) {
@@ -176,7 +176,7 @@ export async function executeInference<T extends z.AnyZodObject>(   {
 
             const result = schema ? await infer<T>({
                 env,
-                metadata: context,
+                metadata: context.metadata,
                 messages,
                 schema,
                 schemaName: agentActionName,
@@ -194,9 +194,10 @@ export async function executeInference<T extends z.AnyZodObject>(   {
                 abortSignal: context.abortSignal,
                 onAssistantMessage,
                 completionConfig,
+                runtimeOverrides: context.runtimeOverrides,
             }) : await infer({
                 env,
-                metadata: context,
+                metadata: context.metadata,
                 messages,
                 maxTokens,
                 modelName: useCheaperModel ? AIModels.GEMINI_2_5_FLASH: modelName,
@@ -208,6 +209,7 @@ export async function executeInference<T extends z.AnyZodObject>(   {
                 abortSignal: context.abortSignal,
                 onAssistantMessage,
                 completionConfig,
+                runtimeOverrides: context.runtimeOverrides,
             });
             logger.info(`Successfully completed ${agentActionName} operation`);
             // console.log(result);

--- a/worker/agents/services/implementations/BaseAgentService.ts
+++ b/worker/agents/services/implementations/BaseAgentService.ts
@@ -36,7 +36,7 @@ export abstract class BaseAgentService<TState extends BaseProjectState = BasePro
     }
 
     getAgentId() {
-        return this.getState().inferenceContext.agentId
+        return this.getState().metadata.agentId
     }
     
     /**

--- a/worker/agents/services/implementations/DeploymentManager.ts
+++ b/worker/agents/services/implementations/DeploymentManager.ts
@@ -564,8 +564,8 @@ export class DeploymentManager extends BaseAgentService<BaseProjectState> implem
                 localEnvVars = {
                     "CF_AI_BASE_URL": generateAppProxyUrl(this.env),
                     "CF_AI_API_KEY": await generateAppProxyToken(
-                        state.inferenceContext.agentId,
-                        state.inferenceContext.userId,
+                        state.metadata.agentId,
+                        state.metadata.userId,
                         this.env
                     )
                 };

--- a/worker/api/controllers/agent/controller.ts
+++ b/worker/api/controllers/agent/controller.ts
@@ -122,9 +122,11 @@ export class CodingAgentController extends BaseController {
             }
 
             const inferenceContext = {
+                metadata: {
+                    agentId: agentId,
+                    userId: user.id,
+                },
                 userModelConfigs,
-                agentId: agentId,
-                userId: user.id,
                 enableRealtimeCodeFix: false, // This costs us too much, so disabled it for now
                 enableFastSmartCodeFix: false,
             }

--- a/worker/database/services/ModelTestService.ts
+++ b/worker/database/services/ModelTestService.ts
@@ -35,8 +35,10 @@ export class ModelTestService extends BaseService {
                 maxTokens: Math.min(modelConfig.max_tokens || 100, 100), // Limit to 100 tokens for test
                 temperature: modelConfig.temperature || 0.1,
                 reasoning_effort: modelConfig.reasoning_effort,
-                userApiKeys,
                 actionKey: 'testModelConfig',
+                runtimeOverrides: {
+                    userApiKeys
+                }
             });
 
             const endTime = Date.now();
@@ -116,7 +118,9 @@ export class ModelTestService extends BaseService {
                 maxTokens: 10,
                 temperature: 0,
                 actionKey: 'testModelConfig',
-                userApiKeys: Object.fromEntries(testApiKeys)
+                runtimeOverrides: {
+                    userApiKeys: Object.fromEntries(testApiKeys)
+                }
             });
 
             const endTime = Date.now();

--- a/worker/services/sandbox/sandboxSdkClient.ts
+++ b/worker/services/sandbox/sandboxSdkClient.ts
@@ -43,7 +43,7 @@ import { generateId } from '../../utils/idGenerator';
 import { ResourceProvisioner } from './resourceProvisioner';
 import { TemplateParser } from './templateParser';
 import { ResourceProvisioningResult } from './types';
-import { getPreviewDomain } from '../../utils/urls';
+import { getPreviewDomain, migratePreviewUrl } from '../../utils/urls';
 import { isDev } from 'worker/utils/envs'
 import { FileTreeBuilder } from './fileTreeBuilder';
 import { DeploymentTarget } from 'worker/agents/core/types';
@@ -538,7 +538,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                         uptime: Math.floor((Date.now() - new Date(metadata.startTime).getTime()) / 1000),
                         directory: instanceId,
                         serviceDirectory: instanceId,
-                        previewURL: metadata.previewURL,
+                        previewURL: migratePreviewUrl(metadata.previewURL, env),
                         processId: metadata.processId,
                         tunnelURL: metadata.tunnelURL,
                         // Skip file tree
@@ -1112,7 +1112,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                 serviceDirectory: instanceId,
                 fileTree,
                 runtimeErrors: runtimeErrors.errors,
-                previewURL: metadata.previewURL,
+                previewURL: migratePreviewUrl(metadata.previewURL, env),
                 processId: metadata.processId,
                 tunnelURL: metadata.tunnelURL,
             };
@@ -1169,7 +1169,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                 pending: false,
                 isHealthy,
                 message: isHealthy ? 'Instance is running normally' : 'Instance may have issues',
-                previewURL: metadata.previewURL,
+                previewURL: migratePreviewUrl(metadata.previewURL, env),
                 tunnelURL: metadata.tunnelURL,
                 processId: metadata.processId
             };


### PR DESCRIPTION
## Summary
Refactors the inference context system to separate persistent metadata (agentId, userId) from runtime-only state (API keys, abort signals, model configs), preventing accidental serialization of sensitive data in Durable Object state.

## Changes
- Split `InferenceContext` into `InferenceMetadata` (persistent) and `InferenceContext` (runtime-assembled)
- Add `InferenceRuntimeOverrides` type for BYOK API keys and AI Gateway overrides
- Move `userModelConfigs` and `runtimeOverrides` from state to behavior instance properties
- Add `credentialsToRuntimeOverrides()` utility for SDK credential payload conversion
- Update `getInferenceContext()` method in `BaseCodingBehavior` to assemble runtime context on-demand
- Rename state field `inferenceContext` -> `metadata` with migration support for legacy state
- Propagate `runtimeOverrides` through inference pipeline to support BYOK keys

## Motivation
The previous design persisted runtime-only data (like user API keys and abort signals) in Durable Object state, which was:
1. A security concern - API keys should never be persisted to storage
2. Architecturally incorrect - mixing persistent and ephemeral data
3. Inefficient - serializing/deserializing unnecessary data

This refactor cleanly separates concerns by:
- Persisting only immutable metadata (agentId, userId)
- Assembling runtime context on-demand when needed for inference

## Testing
- Existing agent tests should pass with migration handling legacy state
- Test BYOK functionality with runtime API key overrides
- Verify state migration from `inferenceContext` to `metadata` for existing apps

## Breaking Changes
- `state.inferenceContext` renamed to `state.metadata` (migration handles legacy data)
- Code accessing inference context must now use `behavior.getInferenceContext()`

## Related Issues
- None identified