### PR TITLE
Release: Nightly to build.cloudflare.dev (fix)

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1980,8 +1980,9 @@ class CloudflareDeploymentManager {
 			this.updateContainerConfiguration();
 			this.updateDispatchNamespace(dispatchNamespacesAvailable);
 
-			// Step 3: Resolve var/secret conflicts before deployment
-			console.log('\n📋 Step 3: Resolving var/secret conflicts...');
+			// Step 3: Create .prod.vars and resolve var/secret conflicts before deployment
+			console.log('\n📋 Step 3: Creating .prod.vars and resolving var/secret conflicts...');
+			this.createProdVarsFile();
 			const conflictingVars = await this.removeConflictingVars();
 			
 			// Store for potential cleanup on early exit


### PR DESCRIPTION
## Summary
Fixes deployment script to create `.prod.vars` file before attempting to resolve var/secret conflicts.

## Changes
- Added `this.createProdVarsFile()` call in Step 3 of the deployment process
- Updated comment and console log message to reflect the new step order

## Motivation
The `removeConflictingVars()` method checks if `.prod.vars` exists and returns early if it doesn't (line 1581-1584). Previously, the `.prod.vars` file was only created on-demand in `updateSecrets()` at Step 6, which meant the conflict resolution in Step 3 would always be skipped. This fix ensures the file is created before attempting to resolve conflicts, allowing the var/secret conflict resolution to work correctly.

## Testing
- Deploy to a Cloudflare environment with conflicting vars between `wrangler.jsonc` and `.prod.vars`
- Verify that the conflict resolution step now correctly identifies and removes conflicting vars

## Breaking Changes
None

## Related Issues
None identified