### PR TITLE
Release: Nightly to build.cloudflare.dev (fix #2)

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1736,7 +1736,13 @@ class CloudflareDeploymentManager {
 			'GITHUB_CLIENT_SECRET',
 			'JWT_SECRET',
 			'WEBHOOK_SECRET',
+			'SECRETS_ENCRYPTION_KEY',
+			'SENTRY_DSN',
 			'MAX_SANDBOX_INSTANCES',
+			'CUSTOM_DOMAIN',
+			'CUSTOM_PREVIEW_DOMAIN',
+			'SANDBOX_INSTANCE_TYPE',
+			'DISPATCH_NAMESPACE',
 		];
 
 		const prodVarsContent: string[] = [


### PR DESCRIPTION
## Summary
Adds 6 new environment variables to the deployment script's secret variables list to ensure they are properly uploaded as secrets to Cloudflare Workers during deployment.

## Changes
- Added `SECRETS_ENCRYPTION_KEY` and `SENTRY_DSN` to the `secretVars` array (after `WEBHOOK_SECRET`)
- Added `CUSTOM_DOMAIN`, `CUSTOM_PREVIEW_DOMAIN`, `SANDBOX_INSTANCE_TYPE`, and `DISPATCH_NAMESPACE` to the `secretVars` array (after `MAX_SANDBOX_INSTANCES`)

## Motivation
These configuration variables need to be treated as secrets during deployment to ensure they are securely uploaded via `wrangler secret bulk` command. This includes:
- `SECRETS_ENCRYPTION_KEY` - Used for encrypting sensitive data
- `SENTRY_DSN` - Sentry error tracking configuration (contains authentication)
- `CUSTOM_DOMAIN` / `CUSTOM_PREVIEW_DOMAIN` - Custom domain configurations
- `SANDBOX_INSTANCE_TYPE` / `DISPATCH_NAMESPACE` - Deployment configuration variables

## Testing
- Deploy the application using the deploy script
- Verify that the new environment variables are included in the generated `.prod.vars` file
- Confirm secrets are uploaded successfully via `wrangler secret bulk`

## Related Issues
- Fixes #2