### PR TITLE
feat: enhance rate limit result with exceeded limit details and limit values

### DIFF
--- a/worker/services/rate-limit/DORateLimitStore.ts
+++ b/worker/services/rate-limit/DORateLimitStore.ts
@@ -22,6 +22,9 @@ export interface RateLimitConfig {
 export interface RateLimitResult {
     success: boolean;
     remainingLimit?: number;
+    exceededLimit?: 'main' | 'burst' | 'daily';
+    limitValue?: number;
+    periodSeconds?: number;
 }
 
 /**
@@ -69,15 +72,33 @@ export class DORateLimitStore extends DurableObject<Env> {
 
         // Check limits
         if (mainCount >= config.limit) {
-            return { success: false, remainingLimit: 0 };
+            return {
+                success: false,
+                remainingLimit: 0,
+                exceededLimit: 'main',
+                limitValue: config.limit,
+                periodSeconds: config.period
+            };
         }
 
         if (config.burst && burstCount >= config.burst) {
-            return { success: false, remainingLimit: 0 };
+            return {
+                success: false,
+                remainingLimit: 0,
+                exceededLimit: 'burst',
+                limitValue: config.burst,
+                periodSeconds: config.burstWindow
+            };
         }
 
         if (config.dailyLimit && dailyCount >= config.dailyLimit) {
-            return { success: false, remainingLimit: 0 };
+            return {
+                success: false,
+                remainingLimit: 0,
+                exceededLimit: 'daily',
+                limitValue: config.dailyLimit,
+                periodSeconds: 24 * 60 * 60
+            };
         }
 
         // Increment current bucket

--- a/worker/services/rate-limit/KVRateLimitStore.ts
+++ b/worker/services/rate-limit/KVRateLimitStore.ts
@@ -39,11 +39,23 @@ export class KVRateLimitStore {
 			const burstCount = burstBuckets.reduce((sum, bucketKey) => sum + (bucketMap.get(bucketKey) || 0), 0);
 
 			if (mainCount >= config.limit) {
-				return { success: false, remainingLimit: 0 };
+				return {
+					success: false,
+					remainingLimit: 0,
+					exceededLimit: 'main',
+					limitValue: config.limit,
+					periodSeconds: config.period
+				};
 			}
 
 			if (config.burst && burstCount >= config.burst) {
-				return { success: false, remainingLimit: 0 };
+				return {
+					success: false,
+					remainingLimit: 0,
+					exceededLimit: 'burst',
+					limitValue: config.burst,
+					periodSeconds: config.burstWindow
+				};
 			}
 
 			const currentBucketKey = `ratelimit:${key}:${currentBucket}`;

--- a/worker/services/rate-limit/rateLimits.ts
+++ b/worker/services/rate-limit/rateLimits.ts
@@ -4,6 +4,7 @@ import { AuthUser } from '../../types/auth-types';
 import { extractTokenWithMetadata, extractRequestMetadata } from '../../utils/authUtils';
 import { captureSecurityEvent } from '../../observability/sentry';
 import { KVRateLimitStore } from './KVRateLimitStore';
+import { RateLimitResult } from './DORateLimitStore';
 import { RateLimitExceededError, SecurityError } from 'shared/types/errors';
 import { isDev } from 'worker/utils/envs';
 import { AI_MODEL_CONFIG, AIModels } from 'worker/agents/inferutils/config.types';
@@ -53,7 +54,7 @@ export class RateLimitService {
         key: string,
         config: DORateLimitConfig,
         incrementBy: number = 1
-    ): Promise<boolean> {
+    ): Promise<RateLimitResult> {
         try {
             const stub = env.DORateLimitStore.getByName(key);
 
@@ -66,13 +67,13 @@ export class RateLimitService {
                 dailyLimit: config.dailyLimit
             }, incrementBy);
 
-            return result.success;
+            return result;
         } catch (error) {
             this.logger.error('Failed to enforce DO rate limit', {
                 key,
                 error: error instanceof Error ? error.message : 'Unknown error'
             });
-            return true; // Fail open
+            return { success: true }; // Fail open
         }
     }
     
@@ -82,32 +83,26 @@ export class RateLimitService {
         config: RateLimitSettings,
         limitType: RateLimitType,
         incrementBy: number = 1
-    ) : Promise<boolean> {
+    ) : Promise<RateLimitResult> {
         // If dev, don't enforce
         if (isDev(env)) {
-            return true;
+            return { success: true };
         }
         const rateLimitConfig = config[limitType];
-        let success = false;
-        
+
         switch (rateLimitConfig.store) {
             case RateLimitStore.RATE_LIMITER: {
                 const result = await (env[rateLimitConfig.bindingName as keyof Env] as RateLimit).limit({ key });
-                success = result.success;
-                break;
+                return { success: result.success };
             }
             case RateLimitStore.KV: {
-                const result = await KVRateLimitStore.increment(env.VibecoderStore, key, rateLimitConfig as KVRateLimitConfig, incrementBy);
-                success = result.success;
-                break;
+                return await KVRateLimitStore.increment(env.VibecoderStore, key, rateLimitConfig as KVRateLimitConfig, incrementBy);
             }
             case RateLimitStore.DURABLE_OBJECT:
-                success = await this.enforceDORateLimit(env, key, rateLimitConfig as DORateLimitConfig, incrementBy);
-                break;
+                return await this.enforceDORateLimit(env, key, rateLimitConfig as DORateLimitConfig, incrementBy);
             default:
-                return false;
+                return { success: false };
         }
-        return success;
     }
 
     static async enforceGlobalApiRateLimit(
@@ -124,8 +119,8 @@ export class RateLimitService {
         const key = this.buildRateLimitKey(RateLimitType.API_RATE_LIMIT, identifier);
         
         try {
-            const success = await this.enforce(env, key, config, RateLimitType.API_RATE_LIMIT);
-            if (!success) {
+            const result = await this.enforce(env, key, config, RateLimitType.API_RATE_LIMIT);
+            if (!result.success) {
                 this.logger.warn('Global API rate limit exceeded', {
                     identifier,
                     key,
@@ -164,8 +159,8 @@ export class RateLimitService {
         const key = this.buildRateLimitKey(RateLimitType.AUTH_RATE_LIMIT, identifier);
         
         try {
-            const success = await this.enforce(env, key, config, RateLimitType.AUTH_RATE_LIMIT);
-            if (!success) {
+            const result = await this.enforce(env, key, config, RateLimitType.AUTH_RATE_LIMIT);
+            if (!result.success) {
                 this.logger.warn('Auth rate limit exceeded', {
                     identifier,
                     key,
@@ -203,11 +198,13 @@ export class RateLimitService {
 		const key = this.buildRateLimitKey(RateLimitType.APP_CREATION, identifier);
 		
 		try {
-            const success = await this.enforce(env, key, config, RateLimitType.APP_CREATION);
-			if (!success) {
+            const result = await this.enforce(env, key, config, RateLimitType.APP_CREATION);
+			if (!result.success) {
 				this.logger.warn('App creation rate limit exceeded', {
 					identifier,
 					key,
+					exceededLimit: result.exceededLimit,
+					limitValue: result.limitValue,
 					userAgent: request.headers.get('User-Agent'),
 					ip: request.headers.get('CF-Connecting-IP')
 				});
@@ -215,15 +212,25 @@ export class RateLimitService {
 					limitType: RateLimitType.APP_CREATION,
 					identifier,
 					key,
+					exceededLimit: result.exceededLimit,
 					userAgent: request.headers.get('User-Agent') || undefined,
 					ip: request.headers.get('CF-Connecting-IP') || undefined,
 				});
+
+				// Build error message based on which limit was exceeded
+				const limitValue = result.limitValue ?? config.appCreation.limit;
+				const periodSeconds = result.periodSeconds ?? config.appCreation.period;
+				const periodHours = periodSeconds / 3600;
+				const periodLabel = result.exceededLimit === 'daily'
+					? 'day'
+					: `${periodHours} hour${periodHours >= 2 ? 's' : ''}`;
+
 				throw new RateLimitExceededError(
-					`App creation rate limit exceeded. Maximum ${config.appCreation.limit} apps per ${config.appCreation.period / 3600} hour${config.appCreation.period >= 7200 ? 's' : ''}`,
+					`App creation rate limit exceeded. Maximum ${limitValue} apps per ${periodLabel}`,
 					RateLimitType.APP_CREATION,
-					config.appCreation.limit,
-					config.appCreation.period,
-                    ['Please try again in an hour when the limit resets for you.']
+					limitValue,
+					periodSeconds,
+                    ['Please try again later when the limit resets for you.']
 				);
 			}
 		} catch (error) {
@@ -254,13 +261,14 @@ export class RateLimitService {
             // Increment by model's credit cost
             const modelConfig = AI_MODEL_CONFIG[model as AIModels];
             const incrementBy = modelConfig.creditCost;
-            
-			const success = await this.enforce(env, key, config, RateLimitType.LLM_CALLS, incrementBy);
-			if (!success) {
+
+			const result = await this.enforce(env, key, config, RateLimitType.LLM_CALLS, incrementBy);
+			if (!result.success) {
 				this.logger.warn('LLM calls rate limit exceeded', {
 					identifier,
 					key,
-                    config,
+					exceededLimit: result.exceededLimit,
+					limitValue: result.limitValue,
                     model,
                     incrementBy
 				});
@@ -268,15 +276,25 @@ export class RateLimitService {
 					limitType: RateLimitType.LLM_CALLS,
 					identifier,
 					key,
+					exceededLimit: result.exceededLimit,
                     model,
                     incrementBy
 				});
+
+				// Build error message based on which limit was exceeded
+				const limitValue = result.limitValue ?? config.llmCalls.limit;
+				const periodSeconds = result.periodSeconds ?? config.llmCalls.period;
+				const periodHours = periodSeconds / 3600;
+				const periodLabel = result.exceededLimit === 'daily'
+					? 'day'
+					: `${periodHours} hour${periodHours >= 2 ? 's' : ''}`;
+
 				throw new RateLimitExceededError(
-					`AI inference rate limit exceeded. Consider using lighter models. Maximum ${config.llmCalls.limit} credits per ${config.llmCalls.period / 3600} hour${config.llmCalls.period >= 7200 ? 's' : ''} or ${config.llmCalls.dailyLimit} credits per day.`,
+					`AI inference rate limit exceeded. Consider using lighter models. Maximum ${limitValue} credits per ${periodLabel}.`,
 					RateLimitType.LLM_CALLS,
-					config.llmCalls.limit,
-					config.llmCalls.period,
-                    [`Please try again in due time when the limit resets for you. The current model costs ${incrementBy} credits per call. Please go to settings to change your default model.`]
+					limitValue,
+					periodSeconds,
+                    [`Please try again later when the limit resets for you. The current model costs ${incrementBy} credits per call. Please go to settings to change your default model.`]
 				);
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary
Enhances the rate limit result object to include detailed information about which limit was exceeded (main, burst, or daily), along with the actual limit value and period duration.

## Changes
- Extended `RateLimitResult` interface with `exceededLimit`, `limitValue`, and `periodSeconds` fields
- Updated `DORateLimitStore.increment()` to return specific limit details on failure
- Updated `KVRateLimitStore.increment()` to return specific limit details on failure
- Modified `RateLimitService.enforce()` to return full `RateLimitResult` instead of boolean
- Improved error messages in `enforceAppCreationRateLimit` and `enforceLLMCallsRateLimit` to use exceeded limit details
- Enhanced logging to include exceeded limit type and value

## Motivation
Previously, when a rate limit was exceeded, the system only returned a boolean success flag. This made it difficult for users to understand:
1. Which specific limit they hit (main period limit, burst limit, or daily limit)
2. What the actual limit value was
3. How long they need to wait

This change provides more actionable error messages that tell users exactly which limit was exceeded and when it resets.

## Testing
- Verify rate limit exceeded errors show correct limit type (main/burst/daily)
- Test that error messages display accurate limit values and periods
- Ensure backwards compatibility with existing rate limit consumers

## Breaking Changes
None - new fields are optional and the API remains backwards compatible.