### PR TITLE
Feat: update model configurations and enhance inference handling

### DIFF
--- a/worker/agents/inferutils/config.ts
+++ b/worker/agents/inferutils/config.ts
@@ -129,10 +129,10 @@ const DEFAULT_AGENT_CONFIG: AgentConfig = {
         temperature: 0.6,
     },
     blueprint: {
-        name: AIModels.GEMINI_3_PRO_PREVIEW,
+        name: AIModels.GEMINI_3_FLASH_PREVIEW,
         reasoning_effort: 'high',
         max_tokens: 64000,
-        fallbackModel: AIModels.GEMINI_2_5_FLASH,
+        fallbackModel: AIModels.GEMINI_2_5_PRO,
         temperature: 1,
     },
     projectSetup: {
@@ -159,10 +159,10 @@ const DEFAULT_AGENT_CONFIG: AgentConfig = {
         fallbackModel: AIModels.GEMINI_2_5_PRO,
     },
     deepDebugger: {
-        name: AIModels.GEMINI_3_PRO_PREVIEW,
+        name: AIModels.GEMINI_3_FLASH_PREVIEW,
         reasoning_effort: 'high',
         max_tokens: 8000,
-        temperature: 0.5,
+        temperature: 1,
         fallbackModel: AIModels.GEMINI_2_5_FLASH,
     },
     fileRegeneration: {
@@ -173,10 +173,10 @@ const DEFAULT_AGENT_CONFIG: AgentConfig = {
         fallbackModel: AIModels.GEMINI_2_5_FLASH,
     },
     agenticProjectBuilder: {
-        name: AIModels.GEMINI_2_5_PRO,
+        name: AIModels.GEMINI_3_FLASH_PREVIEW,
         reasoning_effort: 'high',
         max_tokens: 8000,
-        temperature: 0.5,
+        temperature: 1,
         fallbackModel: AIModels.GEMINI_2_5_FLASH,
     },
 };

--- a/worker/agents/operations/AgenticProjectBuilder.ts
+++ b/worker/agents/operations/AgenticProjectBuilder.ts
@@ -4,8 +4,7 @@ import {
     Message,
     ConversationMessage,
 } from '../inferutils/common';
-import { AgentActionKey, ModelConfig } from '../inferutils/config.types';
-import { AGENT_CONFIG } from '../inferutils/config';
+import { AgentActionKey } from '../inferutils/config.types';
 import { withRenderer } from '../tools/customTools';
 import { RenderToolCall } from './UserConversationProcessor';
 import { PROMPT_UTILS } from '../prompts';
@@ -47,7 +46,6 @@ export interface AgenticProjectBuilderInputs {
     toolRenderer: RenderToolCall;
     onToolComplete?: (message: Message) => Promise<void>;
     onAssistantMessage?: (message: Message) => Promise<void>;
-    modelConfigOverride?: ModelConfig;
 }
 
 export interface AgenticProjectBuilderOutputs {
@@ -293,7 +291,6 @@ export class AgenticProjectBuilderOperation extends AgentOperationWithTools<
 
         return {
             agentActionName: 'agenticProjectBuilder' as AgentActionKey,
-            modelConfig: inputs.modelConfigOverride || AGENT_CONFIG.agenticProjectBuilder,
             completionSignalName: 'mark_generation_complete',
             operationalMode: inputs.operationalMode,
             allowWarningInjection: inputs.operationalMode === 'initial',

--- a/worker/agents/operations/DeepDebugger.ts
+++ b/worker/agents/operations/DeepDebugger.ts
@@ -1,7 +1,6 @@
 import { createSystemMessage, createUserMessage, Message } from '../inferutils/common';
 import { AgentActionKey, ModelConfig } from '../inferutils/config.types';
 import { CompletionConfig, InferError, InferResponseString } from '../inferutils/core';
-import { AGENT_CONFIG } from '../inferutils/config';
 import { buildDebugTools } from '../tools/customTools';
 import { RenderToolCall } from './UserConversationProcessor';
 import { PROMPT_UTILS } from '../prompts';
@@ -82,7 +81,6 @@ export interface DeepDebuggerInputs {
     runtimeErrors?: RuntimeError[];
     streamCb?: (chunk: string) => void;
     toolRenderer?: RenderToolCall;
-    modelConfigOverride?: ModelConfig;
 }
 
 export interface DeepDebuggerOutputs {
@@ -193,7 +191,6 @@ export class DeepDebuggerOperation extends AgentOperationWithTools<
 
         return {
             agentActionName: 'deepDebugger' as AgentActionKey,
-            modelConfig: inputs.modelConfigOverride || AGENT_CONFIG.deepDebugger,
             completionSignalName: 'mark_debugging_complete',
             operationalMode: 'initial' as const,
             allowWarningInjection: true,

--- a/worker/agents/operations/common.ts
+++ b/worker/agents/operations/common.ts
@@ -1,7 +1,7 @@
 import { StructuredLogger } from "../../logger";
 import { GenerationContext } from "../domain/values/GenerationContext";
 import { Message } from "../inferutils/common";
-import { InferenceContext, AgentActionKey, ModelConfig } from "../inferutils/config.types";
+import { InferenceContext, AgentActionKey } from "../inferutils/config.types";
 import { createUserMessage, createSystemMessage, createAssistantMessage } from "../inferutils/common";
 import { generalSystemPromptBuilder, USER_PROMPT_FORMATTER } from "../prompts";
 import { CodeSerializerType } from "../utils/codeSerializers";
@@ -121,7 +121,6 @@ export abstract class AgentOperationWithTools<
         session: TSession
     ): {
         agentActionName: AgentActionKey;
-        modelConfig: ModelConfig;
         completionSignalName?: string;
         operationalMode?: "initial" | "followup";
         allowWarningInjection?: boolean;
@@ -154,7 +153,6 @@ export abstract class AgentOperationWithTools<
             messages: Message[];
             tools: ToolDefinition<unknown, unknown>[];
             agentActionName: AgentActionKey;
-            modelConfig: ModelConfig;
             streamCb?: (chunk: string) => void;
             onAssistantMessage?: (message: Message) => Promise<void>;
             completionConfig?: CompletionConfig;
@@ -165,7 +163,6 @@ export abstract class AgentOperationWithTools<
             messages,
             tools,
             agentActionName,
-            modelConfig,
             streamCb,
             onAssistantMessage,
             completionConfig,
@@ -235,7 +232,6 @@ export abstract class AgentOperationWithTools<
                 abortSignal: controller.signal
             },
             agentActionName,
-            modelConfig,
             messages,
             tools: wrappedTools,
             stream: wrappedStreamCb
@@ -262,7 +258,6 @@ export abstract class AgentOperationWithTools<
 
         const {
             agentActionName,
-            modelConfig,
             completionSignalName,
             operationalMode,
             allowWarningInjection,
@@ -280,7 +275,6 @@ export abstract class AgentOperationWithTools<
             messages,
             tools: rawTools,
             agentActionName,
-            modelConfig,
             streamCb: callbacks.streamCb,
             onAssistantMessage: callbacks.onAssistantMessage,
             completionConfig,


### PR DESCRIPTION
## Summary
Refactors model configuration resolution into a centralized `resolveModelConfig()` function with field-by-field merging, and updates default model configurations for several agents.

## Changes
- **config.ts**: Updated model configurations:
  - `blueprint`: `GEMINI_3_PRO_PREVIEW` → `GEMINI_3_FLASH_PREVIEW`, fallback: `GEMINI_2_5_FLASH` → `GEMINI_2_5_PRO`
  - `deepDebugger`: `GEMINI_3_PRO_PREVIEW` → `GEMINI_3_FLASH_PREVIEW`, temperature: `0.5` → `1`
  - `agenticProjectBuilder`: `GEMINI_2_5_PRO` → `GEMINI_3_FLASH_PREVIEW`, temperature: `0.5` → `1`
- **infer.ts**: Major refactoring:
  - Added `resolveModelConfig()` function for field-by-field merge (userConfig > defaults)
  - Removed `modelConfig` parameter from `InferenceParamsBase`
  - Simplified `executeInference()` by removing ~80 lines of duplicate validation code
  - Fixed temperature handling: changed `||` to `??` to correctly preserve `0` values
  - Removed frequency_penalty retry logic for repetition errors
- **Operation classes**: Removed `modelConfigOverride` from `AgenticProjectBuilderInputs`, `DeepDebuggerInputs`, and the abstract operation base class

## Motivation
The previous model configuration resolution had duplicate validation blocks and complex nested conditionals. This refactoring:
- Centralizes configuration resolution logic in one place
- Makes the precedence rules explicit (userConfig > AGENT_CONFIG defaults)
- Reduces code duplication and improves maintainability
- Fixes edge cases with temperature = 0

## Testing
- Verify inference operations work correctly with the new model configurations
- Test user model config overrides are properly applied
- Ensure fallback model switching works during error retry scenarios

## Breaking Changes
- Removed `modelConfigOverride` parameter from `AgenticProjectBuilderInputs` and `DeepDebuggerInputs`
- Any code relying on these override parameters will need to use `userModelConfigs` in the inference context instead