### PR TITLE
Feat: Auth via ticketing for Websocket

### DIFF
--- a/worker/api/controllers/ticket/controller.ts
+++ b/worker/api/controllers/ticket/controller.ts
@@ -1,0 +1,127 @@
+/**
+ * Ticket Controller
+ *
+ * Creates one-time-use tickets for WebSocket authentication.
+ * Tickets are stored in the appropriate DO and consumed on connection.
+ */
+
+import { BaseController } from '../baseController';
+import { RouteContext } from '../../types/route-context';
+import { createLogger } from '../../../logger';
+import { checkAppOwnership } from '../../../middleware/auth/routeAuth';
+import { generateTicketToken, getResourceStub } from '../../../middleware/auth/ticketAuth';
+import type { TicketResourceType } from '../../../middleware/auth/routeAuth';
+import type { PendingWsTicket, AuthUser } from '../../../types/auth-types';
+
+const TICKET_TTL_MS = 15_000;
+
+interface CreateTicketRequest {
+	resourceType: TicketResourceType;
+	resourceId?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function verifyOwnership(
+	user: AuthUser,
+	resourceType: TicketResourceType,
+	resourceId: string,
+	env: Env
+): Promise<boolean> {
+	switch (resourceType) {
+		case 'agent':
+			return checkAppOwnership(user, { agentId: resourceId }, env);
+		case 'vault':
+			return resourceId === user.id;
+	}
+}
+
+function resolveResourceId(
+	body: CreateTicketRequest,
+	userId: string
+): { resourceId: string } | { error: string } {
+	if (body.resourceType === 'vault') {
+		return { resourceId: userId };
+	}
+	if (!body.resourceId) {
+		return { error: 'resourceId is required for agent tickets' };
+	}
+	return { resourceId: body.resourceId };
+}
+
+// ============================================================================
+// Controller
+// ============================================================================
+
+export class TicketController extends BaseController {
+	static readonly logger = createLogger('TicketController');
+
+	/**
+	 * Create a WebSocket ticket
+	 * POST /api/ws-ticket
+	 */
+	static async createTicket(
+		request: Request,
+		env: Env,
+		_ctx: ExecutionContext,
+		context: RouteContext
+	): Promise<Response> {
+		const user = context.user;
+		if (!user) {
+			return this.createErrorResponse('Authentication required', 401);
+		}
+
+		// Parse and validate request
+		let body: CreateTicketRequest;
+		try {
+			body = await request.json() as CreateTicketRequest;
+		} catch {
+			return this.createErrorResponse('Invalid JSON body', 400);
+		}
+
+		if (!body.resourceType || !['agent', 'vault'].includes(body.resourceType)) {
+			return this.createErrorResponse('Invalid resourceType', 400);
+		}
+
+		// Resolve resource ID
+		const resolved = resolveResourceId(body, user.id);
+		if ('error' in resolved) {
+			return this.createErrorResponse(resolved.error, 400);
+		}
+		const { resourceId } = resolved;
+
+		// Verify ownership
+		if (!await verifyOwnership(user, body.resourceType, resourceId, env)) {
+			this.logger.warn('Ticket creation denied', { userId: user.id, resourceType: body.resourceType, resourceId });
+			return this.createErrorResponse('Access denied', 403);
+		}
+
+		// Create and store ticket
+		const now = Date.now();
+		const ticket: PendingWsTicket = {
+			token: generateTicketToken(body.resourceType, resourceId),
+			user,
+			sessionId: context.sessionId ?? `ticket:${body.resourceType}:${resourceId}`,
+			createdAt: now,
+			expiresAt: now + TICKET_TTL_MS,
+		};
+
+		try {
+			const stub = await getResourceStub(env, body.resourceType, resourceId);
+			await stub.storeWsTicket(ticket);
+
+			this.logger.info('Ticket created', { resourceType: body.resourceType, resourceId, userId: user.id });
+
+			return this.createSuccessResponse({
+				ticket: ticket.token,
+				expiresIn: Math.floor(TICKET_TTL_MS / 1000),
+				expiresAt: new Date(ticket.expiresAt).toISOString(),
+			});
+		} catch (error) {
+			this.logger.error('Failed to create ticket', { resourceType: body.resourceType, resourceId, error });
+			return this.createErrorResponse('Failed to create ticket', 500);
+		}
+	}
+}

--- a/worker/api/routes/codegenRoutes.ts
+++ b/worker/api/routes/codegenRoutes.ts
@@ -19,9 +19,11 @@ export function setupCodegenRoutes(app: Hono<AppEnv>): void {
     // APP EDITING ROUTES (/chat/:id frontend)
     // ========================================
     
-    // WebSocket for app editing - OWNER ONLY (for /chat/:id route)
-    // Only the app owner should be able to connect and modify via WebSocket
-    app.get('/api/agent/:agentId/ws', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.handleWebSocketConnection));
+    // WebSocket for app editing - OWNER ONLY with ticket support
+    // Supports ticket-based auth (SDK) or JWT-based auth (browser)
+    app.get('/api/agent/:agentId/ws', setAuthLevel(AuthConfig.ownerOnly, { 
+        ticketAuth: { resourceType: 'agent', paramName: 'agentId' } 
+    }), adaptController(CodingAgentController, CodingAgentController.handleWebSocketConnection));
     
     // Connect to existing agent for editing - OWNER ONLY
     // Only the app owner should be able to connect for editing purposes

--- a/worker/api/routes/index.ts
+++ b/worker/api/routes/index.ts
@@ -11,6 +11,7 @@ import { setupCodegenRoutes } from './codegenRoutes';
 import { setupScreenshotRoutes } from './imagesRoutes';
 import { setupSentryRoutes } from './sentryRoutes';
 import { setupCapabilitiesRoutes } from './capabilitiesRoutes';
+import { setupTicketRoutes } from './ticketRoutes';
 import { Hono } from "hono";
 import { AppEnv } from "../../types/appenv";
 import { setupStatusRoutes } from './statusRoutes';
@@ -32,6 +33,9 @@ export function setupRoutes(app: Hono<AppEnv>): void {
 
     // Authentication and user management routes
     setupAuthRoutes(app);
+    
+    // WebSocket ticket routes
+    setupTicketRoutes(app);
     
     // Codegen routes
     setupCodegenRoutes(app);

--- a/worker/api/routes/ticketRoutes.ts
+++ b/worker/api/routes/ticketRoutes.ts
@@ -1,0 +1,19 @@
+/**
+ * WebSocket Ticket Routes
+ */
+
+import { Hono } from 'hono';
+import { AppEnv } from '../../types/appenv';
+import { AuthConfig, setAuthLevel } from '../../middleware/auth/routeAuth';
+import { adaptController } from '../honoAdapter';
+import { TicketController } from '../controllers/ticket/controller';
+
+export function setupTicketRoutes(app: Hono<AppEnv>): void {
+	// Create WebSocket ticket - requires authentication
+	// Ownership check is done in the controller based on resourceType
+	app.post(
+		'/api/ws-ticket',
+		setAuthLevel(AuthConfig.authenticated),
+		adaptController(TicketController, TicketController.createTicket)
+	);
+}

--- a/worker/api/routes/userSecretsRoutes.ts
+++ b/worker/api/routes/userSecretsRoutes.ts
@@ -13,9 +13,12 @@ export function setupUserSecretsRoutes(app: Hono<AppEnv>): void {
 	const vaultRouter = new Hono<AppEnv>();
 
 	// WebSocket connection to vault DO - must be before other routes
+	// Supports ticket-based auth (SDK) or JWT-based auth (browser)
 	vaultRouter.get(
 		'/ws',
-		setAuthLevel(AuthConfig.authenticated),
+		setAuthLevel(AuthConfig.authenticated, {
+			ticketAuth: { resourceType: 'vault' }
+		}),
 		adaptController(UserSecretsController, UserSecretsController.handleWebSocketConnection)
 	);
 

--- a/worker/middleware/auth/ticketAuth.ts
+++ b/worker/middleware/auth/ticketAuth.ts
@@ -1,0 +1,188 @@
+/**
+ * WebSocket Ticket Authentication
+ *
+ * Provides ticket-based authentication for WebSocket connections.
+ * Tickets are opaque, one-time-use tokens stored in DO memory.
+ *
+ * Token formats:
+ * - Agent: tk_{random} (resource ID from URL param)
+ * - Vault: tkv_{userId}_{random} (resource ID encoded in token)
+ */
+
+import { getAgentStub } from '../../agents';
+import type { AuthUserSession, PendingWsTicket, TicketConsumptionResult } from '../../types/auth-types';
+import { createLogger } from '../../logger';
+import type { TicketAuthConfig, TicketResourceType } from './routeAuth';
+
+const logger = createLogger('TicketAuth');
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const MIN_TICKET_LENGTH = 35;
+const AGENT_TICKET_PREFIX = 'tk_';
+const VAULT_TICKET_PREFIX = 'tkv_';
+const AGENT_TICKET_PATTERN = /^tk_[a-f0-9]+$/;
+
+// ============================================================================
+// Interfaces
+// ============================================================================
+
+/**
+ * Interface for DOs that support WebSocket ticket authentication
+ */
+export interface TicketAuthenticatable {
+	storeWsTicket(ticket: PendingWsTicket): Promise<void> | void;
+	consumeWsTicket(token: string): Promise<TicketConsumptionResult | null> | TicketConsumptionResult | null;
+}
+
+// ============================================================================
+// Resource Stub Resolution
+// ============================================================================
+
+/**
+ * Get a resource stub that supports ticket authentication
+ */
+export async function getResourceStub(
+	env: Env,
+	resourceType: TicketResourceType,
+	resourceId: string
+): Promise<TicketAuthenticatable> {
+	switch (resourceType) {
+		case 'agent':
+			return getAgentStub(env, resourceId);
+		case 'vault': {
+			const id = env.UserSecretsStore.idFromName(resourceId);
+			return env.UserSecretsStore.get(id);
+		}
+	}
+}
+
+// ============================================================================
+// Ticket Extraction & Validation
+// ============================================================================
+
+/**
+ * Check if request has a ticket parameter
+ */
+export function hasTicketParam(request: Request): boolean {
+	return new URL(request.url).searchParams.has('ticket');
+}
+
+/**
+ * Extract ticket from request, returning null if not present or invalid format
+ */
+function extractAndValidateTicket(
+	request: Request,
+	resourceType: TicketResourceType
+): string | null {
+	const ticket = new URL(request.url).searchParams.get('ticket');
+	if (!ticket || ticket.length < MIN_TICKET_LENGTH) {
+		return null;
+	}
+
+	if (resourceType === 'vault') {
+		return ticket.startsWith(VAULT_TICKET_PREFIX) && parseVaultTicket(ticket) ? ticket : null;
+	}
+
+	return ticket.startsWith(AGENT_TICKET_PREFIX) && AGENT_TICKET_PATTERN.test(ticket) ? ticket : null;
+}
+
+/**
+ * Parse a vault ticket to extract the user ID
+ * Format: tkv_{userId}_{random}
+ */
+function parseVaultTicket(ticket: string): string | null {
+	const withoutPrefix = ticket.slice(VAULT_TICKET_PREFIX.length);
+	const separatorIndex = withoutPrefix.indexOf('_');
+	if (separatorIndex <= 0) {
+		return null;
+	}
+	return withoutPrefix.slice(0, separatorIndex);
+}
+
+/**
+ * Resolve the resource ID from ticket and route params
+ */
+function resolveResourceId(
+	ticket: string,
+	config: TicketAuthConfig,
+	params: Record<string, string>
+): string | null {
+	if (config.resourceType === 'vault') {
+		return parseVaultTicket(ticket);
+	}
+
+	if (!config.paramName) {
+		logger.error('paramName required for agent ticket auth');
+		return null;
+	}
+
+	return params[config.paramName] || null;
+}
+
+// ============================================================================
+// Authentication
+// ============================================================================
+
+/**
+ * Authenticate a request via WebSocket ticket
+ */
+export async function authenticateViaTicket(
+	request: Request,
+	env: Env,
+	config: TicketAuthConfig,
+	params: Record<string, string>
+): Promise<AuthUserSession | null> {
+	const ticket = extractAndValidateTicket(request, config.resourceType);
+	if (!ticket) {
+		logger.warn('Invalid or missing ticket', { resourceType: config.resourceType });
+		return null;
+	}
+
+	const resourceId = resolveResourceId(ticket, config, params);
+	if (!resourceId) {
+		logger.warn('Could not resolve resource ID', { resourceType: config.resourceType });
+		return null;
+	}
+
+	try {
+		const stub = await getResourceStub(env, config.resourceType, resourceId);
+		const result = await stub.consumeWsTicket(ticket);
+
+		if (!result) {
+			logger.warn('Ticket consumption failed', { resourceType: config.resourceType, resourceId });
+			return null;
+		}
+
+		logger.info('Ticket authenticated', {
+			resourceType: config.resourceType,
+			resourceId,
+			userId: result.user.id,
+		});
+
+		return { user: result.user, sessionId: result.sessionId };
+	} catch (error) {
+		logger.error('Ticket authentication error', { resourceType: config.resourceType, resourceId, error });
+		return null;
+	}
+}
+
+// ============================================================================
+// Token Generation
+// ============================================================================
+
+/**
+ * Generate a ticket token for the specified resource
+ */
+export function generateTicketToken(resourceType: TicketResourceType, resourceId: string): string {
+	const random = crypto.randomUUID().replace(/-/g, '');
+
+	switch (resourceType) {
+		case 'vault':
+			return `${VAULT_TICKET_PREFIX}${resourceId}_${random}`;
+		case 'agent':
+			return `${AGENT_TICKET_PREFIX}${random}`;
+	}
+}

--- a/worker/types/appenv.ts
+++ b/worker/types/appenv.ts
@@ -1,5 +1,5 @@
 import { GlobalConfigurableSettings } from "../config";
-import { AuthRequirement } from "../middleware/auth/routeAuth";
+import { AuthLevelOptions, AuthRequirement } from "../middleware/auth/routeAuth";
 import { AuthUser } from "./auth-types";
 
 
@@ -10,5 +10,6 @@ export type AppEnv = {
         sessionId: string | null;
         config: GlobalConfigurableSettings;
         authLevel: AuthRequirement;
+        authLevelOptions?: AuthLevelOptions;
     }
 }

--- a/worker/types/auth-types.ts
+++ b/worker/types/auth-types.ts
@@ -170,3 +170,23 @@ export interface SecurityContext {
 export type AuditLogEntry = AuditLog & {
 	securityContext?: Partial<SecurityContext>;
 };
+
+/**
+ * WebSocket ticket for secure, one-time-use authentication
+ * Stored in Agent DO memory, consumed on WebSocket connection
+ */
+export interface PendingWsTicket {
+	token: string;
+	user: AuthUser;
+	sessionId: string;
+	createdAt: number;
+	expiresAt: number;
+}
+
+/**
+ * Result of ticket consumption from Agent DO
+ */
+export interface TicketConsumptionResult {
+	user: AuthUser;
+	sessionId: string;
+}

--- a/worker/utils/wsTicketManager.ts
+++ b/worker/utils/wsTicketManager.ts
@@ -1,0 +1,66 @@
+/**
+ * WebSocket Ticket Manager
+ */
+
+import { PendingWsTicket, TicketConsumptionResult } from '../types/auth-types';
+
+/**
+ * Manages in-memory storage of WebSocket tickets.
+ */
+export class WsTicketManager {
+	private tickets = new Map<string, PendingWsTicket>();
+
+	/**
+	 * Store a ticket for later consumption
+	 */
+	store(ticket: PendingWsTicket): void {
+		this.tickets.set(ticket.token, ticket);
+
+		// Schedule auto-cleanup after expiry
+		const ttl = ticket.expiresAt - Date.now();
+		if (ttl > 0) {
+			setTimeout(() => {
+				this.tickets.delete(ticket.token);
+			}, ttl + 1000); // +1s buffer
+		}
+	}
+
+	/**
+	 * Consume a ticket (one-time use)
+	 * Returns user session if valid, null otherwise
+	 */
+	consume(token: string): TicketConsumptionResult | null {
+		const ticket = this.tickets.get(token);
+
+		if (!ticket) {
+			return null;
+		}
+
+		// Delete immediately (one-time use)
+		this.tickets.delete(token);
+
+		// Check expiry
+		if (Date.now() > ticket.expiresAt) {
+			return null;
+		}
+
+		return {
+			user: ticket.user,
+			sessionId: ticket.sessionId,
+		};
+	}
+
+	/**
+	 * Check if a ticket exists (without consuming it)
+	 */
+	has(token: string): boolean {
+		return this.tickets.has(token);
+	}
+
+	/**
+	 * Get the number of pending tickets
+	 */
+	get size(): number {
+		return this.tickets.size;
+	}
+}


### PR DESCRIPTION
## Summary
Implements a ticket-based authentication system for WebSocket connections, enabling SDK clients to authenticate without relying on browser cookies or origin validation.

## Changes
- **New ticket system** (`worker/middleware/auth/ticketAuth.ts`): One-time-use tokens with 15-second TTL for WebSocket auth
- **Ticket manager** (`worker/utils/wsTicketManager.ts`): In-memory storage with automatic expiry cleanup
- **Ticket controller** (`worker/api/controllers/ticket/controller.ts`): POST `/api/ws-ticket` endpoint for ticket creation
- **Route updates**: Added ticket auth support to agent and vault WebSocket routes
- **Auth middleware** (`worker/middleware/auth/routeAuth.ts`): Extended to support dual auth strategies (ticket or JWT)
- **Durable Objects**: Added ticket store/consume methods to `CodeGeneratorAgent` and `UserSecretsStore`

## Motivation
SDK clients (non-browser environments) cannot rely on cookie-based authentication or pass origin headers. This ticket system provides:
1. Secure, short-lived tokens that can be passed as URL parameters
2. One-time-use consumption to prevent replay attacks
3. Origin-agnostic authentication for programmatic access
4. Ownership verification at ticket creation time

## Testing
1. Create a ticket via `POST /api/ws-ticket` with JWT auth
2. Connect to WebSocket with `?ticket=tk_xxx` parameter
3. Verify one-time use (second connection with same ticket fails)
4. Verify expiry (ticket invalid after 15 seconds)

## Security Considerations
- Tickets are one-time-use and deleted on consumption
- Short TTL (15 seconds) limits exposure window
- Ownership verified at ticket creation via existing `checkAppOwnership`
- Ticket format includes resource type prefix for validation
- Rate limiting applied at ticket creation endpoint

## Breaking Changes
None - existing JWT/cookie authentication continues to work unchanged.