### PR TITLE
feat: expand drizzle types script on sdk bundle

### DIFF
--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "@vibesdk/sdk",
+      "name": "@cf-vibesdk/sdk",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
         "@types/node": "^25.0.3",
@@ -33,7 +33,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251217.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rP6USX+7ctynz3AtmKi+EvlLP3Xdr1ETrSdcnv693/I5QdUwBxq4yE1Lj6CV7GJizX6opXKYg8QMq0Q4eB9zRQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251221.0", "", {}, "sha512-VVTEhY29TtwIwjBjpRrdT51Oqu0JlXijc5TiEKFCjwouUSn+5VhzoTSaz7UBjVOu4vfvcQmjqt/dzwBUR7c95w=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251225.0", "", {}, "sha512-ZZl0cNLFcsBRFKtMftKWOsfAybUYSeiTMzpQV1NlTVlByHAs1rGQt45Jw/qz8LrfHoq9PGTieSj9W350Gi4Pvg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -143,7 +143,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.11.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.3", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ=="],
 
-    "@sindresorhus/is": ["@sindresorhus/is@7.1.1", "", {}, "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ=="],
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.12", "", {}, "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="],
 
@@ -373,7 +373,7 @@
 
     "workerd": ["workerd@1.20251217.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20251217.0", "@cloudflare/workerd-darwin-arm64": "1.20251217.0", "@cloudflare/workerd-linux-64": "1.20251217.0", "@cloudflare/workerd-linux-arm64": "1.20251217.0", "@cloudflare/workerd-windows-64": "1.20251217.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-s3mHDSWwHTduyY8kpHOsl27ZJ4ziDBJlc18PfBvNMqNnhO7yBeemlxH7bo7yQyU1foJrIZ6IENHDDg0Z9N8zQA=="],
 
-    "wrangler": ["wrangler@4.56.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.1", "@cloudflare/unenv-preset": "2.7.13", "blake3-wasm": "2.1.5", "esbuild": "0.27.0", "miniflare": "4.20251217.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20251217.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20251217.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Nqi8duQeRbA+31QrD6QlWHW3IZVnuuRxMy7DEg46deUzywivmaRV/euBN5KKXDPtA24VyhYsK7I0tkb7P5DM2w=="],
+    "wrangler": ["wrangler@4.54.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.1", "@cloudflare/unenv-preset": "2.7.13", "blake3-wasm": "2.1.5", "esbuild": "0.27.0", "miniflare": "4.20251210.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20251210.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20251210.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bANFsjDwJLbprYoBK+hUDZsVbUv2SqJd8QvArLIcZk+fPq4h/Ohtj5vkKXD3k0s2bD1DXLk08D+hYmeNH+xC6A=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -400,5 +400,19 @@
     "puppeteer-core/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
+    "wrangler/miniflare": ["miniflare@4.20251210.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20251210.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-k6kIoXwGVqlPZb0hcn+X7BmnK+8BjIIkusQPY22kCo2RaQJ/LzAjtxHQdGXerlHSnJyQivDQsL6BJHMpQfUFyw=="],
+
+    "wrangler/workerd": ["workerd@1.20251210.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20251210.0", "@cloudflare/workerd-darwin-arm64": "1.20251210.0", "@cloudflare/workerd-linux-64": "1.20251210.0", "@cloudflare/workerd-linux-arm64": "1.20251210.0", "@cloudflare/workerd-windows-64": "1.20251210.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-9MUUneP1BnRE9XAYi94FXxHmiLGbO75EHQZsgWqSiOXjoXSqJCw8aQbIEPxCy19TclEl/kHUFYce8ST2W+Qpjw=="],
+
+    "wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20251210.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Nn9X1moUDERA9xtFdCQ2XpQXgAS9pOjiCxvOT8sVx9UJLAiBLkfSCGbpsYdarODGybXCpjRlc77Yppuolvt7oQ=="],
+
+    "wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20251210.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mg8iYIZQFnbevq/ls9eW/eneWTk/EE13Pej1MwfkY5et0jVpdHnvOLywy/o+QtMJFef1AjsqXGULwAneYyBfHw=="],
+
+    "wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20251210.0", "", { "os": "linux", "cpu": "x64" }, "sha512-kjC2fCZhZ2Gkm1biwk2qByAYpGguK5Gf5ic8owzSCUw0FOUfQxTZUT9Lp3gApxsfTLbbnLBrX/xzWjywH9QR4g=="],
+
+    "wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20251210.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-2IB37nXi7PZVQLa1OCuO7/6pNxqisRSO8DmCQ5x/3sezI5op1vwOxAcb1osAnuVsVN9bbvpw70HJvhKruFJTuA=="],
+
+    "wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251210.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Uaz6/9XE+D6E7pCY4OvkCuJHu7HcSDzeGcCGY1HLhojXhHd7yL52c3yfiyJdS8hPatiAa0nn5qSI/42+aTdDSw=="],
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cf-vibesdk/sdk",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"type": "module",
 	"exports": {
 		".": {
@@ -19,7 +19,7 @@
 	},
 	"scripts": {
 		"build": "rm -rf ./dist && bun build ./src/index.ts --outdir ./dist --target browser",
-		"bundle-types": "dts-bundle-generator --export-referenced-types false --no-check --project ./tsconfig.protocol.json -o ./dist/index.d.ts ./src/index.ts",
+		"bundle-types": "dts-bundle-generator --export-referenced-types false --no-check --project ./tsconfig.protocol.json -o ./dist/index.d.ts ./src/index.ts && bun run scripts/expand-drizzle-types.ts",
 		"typecheck": "tsc -p ./tsconfig.json --noEmit",
 		"test": "bun test test/*.test.ts",
 		"test:integration": "bun test --timeout 600000 test/integration/*.test.ts"

--- a/sdk/scripts/expand-drizzle-types.ts
+++ b/sdk/scripts/expand-drizzle-types.ts
@@ -1,0 +1,200 @@
+/**
+ * Post-processes bundled .d.ts to expand Drizzle $inferSelect types.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+
+const DTS_PATH = './dist/index.d.ts';
+
+interface ColumnInfo {
+	name: string;
+	dataType: string;
+	notNull: boolean;
+}
+
+interface TableInfo {
+	columns: Record<string, ColumnInfo>;
+}
+
+// Store expanded types for later reference
+const expandedTypes = new Map<string, TableInfo>();
+
+/**
+ * Parse a table definition from the .d.ts content to extract column info
+ */
+function parseTableDefinition(content: string, tableName: string): TableInfo | null {
+	// Match: declare const tableName: import("drizzle-orm/sqlite-core").SQLiteTableWithColumns<{
+	const tableRegex = new RegExp(
+		`declare const ${tableName}:\\s*import\\("drizzle-orm/sqlite-core"\\)\\.SQLiteTableWithColumns<\\{[^}]*columns:\\s*\\{`,
+		's'
+	);
+
+	const tableMatch = content.match(tableRegex);
+	if (!tableMatch) {
+		return null;
+	}
+
+	const startIndex = tableMatch.index! + tableMatch[0].length;
+
+	// Find the columns block by tracking brace depth
+	let braceDepth = 1;
+	let endIndex = startIndex;
+	for (let i = startIndex; i < content.length && braceDepth > 0; i++) {
+		if (content[i] === '{') braceDepth++;
+		if (content[i] === '}') braceDepth--;
+		endIndex = i;
+	}
+
+	const columnsBlock = content.slice(startIndex, endIndex);
+
+	// Parse each column
+	const columns: Record<string, ColumnInfo> = {};
+
+	// Match column definitions: columnName: import("drizzle-orm/sqlite-core").SQLiteColumn<{...}>
+	const columnRegex = /(\w+):\s*import\("drizzle-orm\/sqlite-core"\)\.SQLiteColumn<\{([^>]+)\}>/gs;
+	let match;
+
+	while ((match = columnRegex.exec(columnsBlock)) !== null) {
+		const columnName = match[1];
+		const columnDef = match[2];
+
+		// Extract data type
+		const dataMatch = columnDef.match(/data:\s*([^;]+);/);
+		// Extract notNull
+		const notNullMatch = columnDef.match(/notNull:\s*(true|false)/);
+
+		if (dataMatch) {
+			const dataType = dataMatch[1].trim();
+
+			columns[columnName] = {
+				name: columnName,
+				dataType,
+				notNull: notNullMatch ? notNullMatch[1] === 'true' : false,
+			};
+		}
+	}
+
+	return { columns };
+}
+
+/**
+ * Generate an expanded type string from column info
+ * @param serializeDates - if true, convert Date to string (for Serialized<T> types)
+ */
+function generateExpandedType(tableInfo: TableInfo, serializeDates = false): string {
+	const fields = Object.entries(tableInfo.columns)
+		.map(([name, col]) => {
+			let dataType = col.dataType;
+			
+			// Convert Date to string for serialized types
+			if (serializeDates && dataType === 'Date') {
+				dataType = 'string';
+			}
+			
+			const type = col.notNull ? dataType : `${dataType} | null`;
+			return `\t${name}: ${type};`;
+		})
+		.join('\n');
+
+	return `{\n${fields}\n}`;
+}
+
+/**
+ * Find all tables referenced by $inferSelect in the content
+ */
+function findInferSelectReferences(content: string): Map<string, string[]> {
+	const refs = new Map<string, string[]>();
+
+	// Match: type TypeName = typeof tableName.$inferSelect;
+	const regex = /type\s+(\w+)\s*=\s*typeof\s+(\w+)\.\$inferSelect;/g;
+	let match;
+
+	while ((match = regex.exec(content)) !== null) {
+		const typeName = match[1];
+		const tableName = match[2];
+
+		if (!refs.has(tableName)) {
+			refs.set(tableName, []);
+		}
+		refs.get(tableName)!.push(typeName);
+	}
+
+	return refs;
+}
+
+/**
+ * Find Serialized<TypeName> patterns where TypeName is an expanded type
+ */
+function expandSerializedTypes(content: string): string {
+	// Find patterns like: type Foo = Serialized<Bar>;
+	// where Bar is one of our expanded types
+	
+	for (const [typeName, tableInfo] of expandedTypes) {
+		// Match: Serialized<TypeName>
+		const serializedRegex = new RegExp(`Serialized<${typeName}>`, 'g');
+		
+		if (serializedRegex.test(content)) {
+			const serializedExpanded = generateExpandedType(tableInfo, true);
+			content = content.replace(serializedRegex, serializedExpanded);
+			console.log(`  Expanded Serialized<${typeName}>`);
+		}
+	}
+	
+	return content;
+}
+
+function main() {
+	console.log('Expanding Drizzle $inferSelect types...');
+
+	let content = readFileSync(DTS_PATH, 'utf-8');
+
+	// Find all $inferSelect references
+	const inferSelectRefs = findInferSelectReferences(content);
+	console.log(`Found ${inferSelectRefs.size} tables with $inferSelect references`);
+
+	// Process each table
+	for (const [tableName, typeNames] of inferSelectRefs) {
+		console.log(`  Processing table: ${tableName} (types: ${typeNames.join(', ')})`);
+
+		const tableInfo = parseTableDefinition(content, tableName);
+		if (!tableInfo) {
+			console.warn(`    Warning: Could not parse table definition for ${tableName}`);
+			continue;
+		}
+
+		const columnCount = Object.keys(tableInfo.columns).length;
+		console.log(`    Found ${columnCount} columns`);
+
+		const expandedType = generateExpandedType(tableInfo);
+
+		// Replace each type alias with the expanded type
+		for (const typeName of typeNames) {
+			const oldDecl = `type ${typeName} = typeof ${tableName}.$inferSelect;`;
+			const newDecl = `type ${typeName} = ${expandedType}`;
+
+			if (content.includes(oldDecl)) {
+				content = content.replace(oldDecl, newDecl);
+				console.log(`    Replaced: ${typeName}`);
+				
+				// Store for Serialized expansion
+				expandedTypes.set(typeName, tableInfo);
+			}
+		}
+	}
+
+	// Also remove $inferInsert references (replace with unknown for now)
+	const inferInsertRegex = /type\s+(\w+)\s*=\s*typeof\s+(\w+)\.\$inferInsert;/g;
+	content = content.replace(inferInsertRegex, (match, typeName, tableName) => {
+		console.log(`  Removing $inferInsert reference: ${typeName}`);
+		return `type ${typeName} = Record<string, unknown>;`;
+	});
+
+	// Now expand Serialized<T> types
+	console.log('\nExpanding Serialized<T> types...');
+	content = expandSerializedTypes(content);
+
+	writeFileSync(DTS_PATH, content);
+	console.log('\nDone!');
+}
+
+main();


### PR DESCRIPTION
## Summary
Adds a post-processing script to expand Drizzle ORM `$inferSelect` types in the SDK's bundled TypeScript declarations, improving type compatibility and usability for consumers.

## Changes
- **sdk/scripts/expand-drizzle-types.ts** (new): Post-processing script that:
  - Parses Drizzle SQLite table definitions from bundled .d.ts files
  - Expands `$inferSelect` type aliases to concrete object types with column definitions
  - Expands `Serialized<T>` types to include serialized forms (Date -> string)
  - Replaces `$inferInsert` references with `Record<string, unknown>`
- **sdk/package.json**: Updated `bundle-types` script to run the new expansion script after dts-bundle-generator
- **sdk/bun.lock**: Dependency updates (workers-types, sindresorhus/is, wrangler)

## Motivation
The bundled SDK types include Drizzle ORM table references that use `$inferSelect` and `$inferInsert`. These Drizzle-specific type constructs may not resolve correctly for SDK consumers who don't have drizzle-orm installed, resulting in broken type inference. This script expands these types inline to ensure SDK types are self-contained.

## Testing
- Run `bun run bundle-types` in the sdk directory
- Verify `dist/index.d.ts` contains expanded object types instead of `$inferSelect` references

## Breaking Changes
None - this is purely additive to the build process and should improve type inference for SDK consumers.