### PR TITLE
feat: add phase timeline change subscription and event handling

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -250,6 +250,24 @@ if (session.phases.allCompleted()) {
 
 // Get phase by ID
 const phase = session.phases.get('phase-0');
+
+// Subscribe to phase changes
+const unsubscribe = session.phases.onChange((event) => {
+  console.log(`Phase ${event.type}:`, event.phase.name);
+  console.log(`Status: ${event.phase.status}`);
+  console.log(`Total phases: ${event.allPhases.length}`);
+});
+// Later: unsubscribe();
+```
+
+The `onChange` callback receives a `PhaseTimelineEvent`:
+
+```ts
+type PhaseTimelineEvent = {
+  type: 'added' | 'updated';  // New phase vs status/file change
+  phase: PhaseInfo;           // The affected phase
+  allPhases: PhaseInfo[];     // All phases after this change
+};
 ```
 
 Each phase contains:
@@ -403,6 +421,8 @@ import type {
   PhaseStatus,
   PhaseFileStatus,
   PhaseEventType,
+  PhaseTimelineEvent,
+  PhaseTimelineChangeType,
   
   // API
   ApiResponse,

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cf-vibesdk/sdk",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"type": "module",
 	"exports": {
 		".": {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,6 +38,8 @@ export type {
 	PhaseFileStatus,
 	PhaseInfo,
 	PhaseStatus,
+	PhaseTimelineChangeType,
+	PhaseTimelineEvent,
 	ProjectType,
 	PublicAppsQuery,
 	SessionDeployable,

--- a/sdk/src/session.ts
+++ b/sdk/src/session.ts
@@ -9,6 +9,7 @@ import type {
 	ImageAttachment,
 	PhaseEventType,
 	PhaseInfo,
+	PhaseTimelineEvent,
 	ProjectType,
 	SessionDeployable,
 	SessionFiles,
@@ -129,6 +130,14 @@ export class BuildSession {
 		allCompleted: (): boolean =>
 			this.state.get().phases.length > 0 &&
 			this.state.get().phases.every((p) => p.status === 'completed'),
+
+		/**
+		 * Subscribe to phase timeline changes.
+		 * Fires when a phase is added or when a phase's status/files change.
+		 * @returns Unsubscribe function.
+		 */
+		onChange: (cb: (event: PhaseTimelineEvent) => void): (() => void) =>
+			this.state.onPhaseChange(cb),
 	};
 
 	readonly wait = {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -186,6 +186,9 @@ export type AgentEventMap = {
 		| 'cloudflare_deployment_error'
 	>;
 	error: { error: string };
+
+	/** Emitted when the phase timeline changes (phase added or updated). */
+	phases: PhaseTimelineEvent;
 };
 
 // ============================================================================
@@ -304,6 +307,20 @@ export type SessionPhases = {
 	count: () => number;
 	/** Check if all phases are completed. */
 	allCompleted: () => boolean;
+};
+
+/**
+ * Event emitted when the phase timeline changes.
+ */
+export type PhaseTimelineChangeType = 'added' | 'updated';
+
+export type PhaseTimelineEvent = {
+	/** Type of change: 'added' for new phase, 'updated' for status/file changes. */
+	type: PhaseTimelineChangeType;
+	/** The phase that was added or updated. */
+	phase: PhaseInfo;
+	/** All phases in the timeline after this change. */
+	allPhases: PhaseInfo[];
 };
 
 export type SessionDeployable = {


### PR DESCRIPTION
## Summary
Adds phase timeline change subscription capability to the SDK, enabling consumers to receive real-time notifications when phases are added or updated during code generation.

## Changes
- Added `PhaseTimelineEvent` and `PhaseTimelineChangeType` types to the SDK type definitions
- Implemented `onPhaseChange` subscription method in `SessionStateStore`
- Exposed `session.phases.onChange()` API for subscribing to phase timeline changes
- Fixed default file status from `'generating'` to `'pending'` for more accurate initial state
- Added `phases` event to `AgentEventMap` for type documentation
- Bumped SDK version from 0.0.8 to 0.0.9

## Motivation
SDK consumers need a way to react to phase lifecycle events (phase added, status changes, file status changes) for building real-time UIs that display code generation progress. This feature enables that by providing a subscription-based API that emits events when the phase timeline changes.

## Testing
- Added comprehensive tests for `onPhaseChange` functionality:
  - Emitting 'added' events for new phases
  - Emitting 'updated' events for status/file changes
  - Full phase lifecycle event sequence
  - Unsubscribe functionality
  - No events when phases unchanged
  - Multiple phases from `agent_connected` restoration

## Breaking Changes
None - this is an additive feature.

## Related Issues
None identified