### PR TITLE
[FIX] only owner can export code to github repo

### DIFF
--- a/worker/api/controllers/githubExporter/controller.ts
+++ b/worker/api/controllers/githubExporter/controller.ts
@@ -261,6 +261,16 @@ export class GitHubExporterController extends BaseController {
             });
 
             if (purpose === 'repository_export' && exportData && agentId) {
+                const appService = new AppService(env);
+                const ownershipResult = await appService.checkAppOwnership(agentId, userId);
+                if (!ownershipResult.isOwner) {
+                    this.logger.warn('OAuth callback ownership check failed', { userId, agentId });
+                    return Response.redirect(
+                        `${returnUrl}?github_export=error&reason=${encodeURIComponent('You do not have permission to export this app')}`,
+                        302,
+                    );
+                }
+
                 const result = await this.createRepositoryAndPush({
                     env,
                     agentId,


### PR DESCRIPTION
### Summary
Adds ownership verification to the GitHub OAuth callback to prevent unauthorized users from exporting apps they don't own.

### Changes
Added `AppService.checkAppOwnership()` call in `GitHubExporterController.handleCallback()` before allowing repository export
Returns a 302 redirect with an error message if the authenticated user is not the app owner
Motivation

Security Fix: The OAuth callback for GitHub repository export was vulnerable to state manipulation. An attacker could potentially craft a malicious OAuth state containing another user's `agentId`, then complete the OAuth flow with their own GitHub account to export someone else's app code to their repository.

This fix ensures that even if the OAuth state is manipulated, the backend verifies that the authenticated user actually owns the app before proceeding with the export.

### Testing
Attempt to export your own app to GitHub → should succeed
Manipulate the OAuth state to include a different user's `agentId` → should fail with "You do not have permission to export this app"

### Breaking Changes
None. This is a security hardening change with no API modifications.