### PR TITLE
[FIX] only app owner should be able to deploy preview

### DIFF
--- a/worker/api/routes/codegenRoutes.ts
+++ b/worker/api/routes/codegenRoutes.ts
@@ -27,5 +27,7 @@ export function setupCodegenRoutes(app: Hono<AppEnv>): void {
     // Only the app owner should be able to connect for editing purposes
     app.get('/api/agent/:agentId/connect', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.connectToExistingAgent));
 
-    app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.authenticated), adaptController(CodingAgentController, CodingAgentController.deployPreview));
+    // Deploy preview - OWNER ONLY
+    // Only the app owner should be able to deploy previews
+    app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.deployPreview));
 }


### PR DESCRIPTION
### Summary

Fixes an Insecure Direct Object Reference (IDOR) vulnerability in the `/api/agent/:agentId/preview` endpoint that allowed any authenticated user to deploy previews of another user's private apps.

### Vulnerability Details

**Affected Endpoint:** `GET /api/agent/:agentId/preview`

**Issue:** The endpoint used `AuthConfig.authenticated` which only verified the user was logged in, without checking if they owned the agent/app.

### Fix

Changed authorization from `AuthConfig.authenticated` to `AuthConfig.ownerOnly`, which invokes `checkAppOwnership()` to verify the authenticated user owns the agent before allowing preview deployment.

```diff
- app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.authenticated), ...);
+ app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.ownerOnly), ...);
```

This is consistent with the other agent routes (`/ws`, `/connect`) which already use `ownerOnly`.

### Testing

- [ ] Verify unauthorized users receive 403 on preview endpoint
- [ ] Verify app owners can still deploy previews successfully