### PR TITLE
Revert "[FIX] only app owner should be able to deploy preview"

### DIFF
--- a/worker/api/routes/codegenRoutes.ts
+++ b/worker/api/routes/codegenRoutes.ts
@@ -27,7 +27,5 @@ export function setupCodegenRoutes(app: Hono<AppEnv>): void {
     // Only the app owner should be able to connect for editing purposes
     app.get('/api/agent/:agentId/connect', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.connectToExistingAgent));
 
-    // Deploy preview - OWNER ONLY
-    // Only the app owner should be able to deploy previews
-    app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.deployPreview));
+    app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.authenticated), adaptController(CodingAgentController, CodingAgentController.deployPreview));
 }


### PR DESCRIPTION
## Summary
Reverts PR #304 which added owner-only authorization to the `/api/agent/:agentId/preview` endpoint.

## Changes
- Changed `/api/agent/:agentId/preview` authorization from `AuthConfig.ownerOnly` back to `AuthConfig.authenticated`
- Removed explanatory comments about owner-only access

## Impact
- **Before this revert:** Only app owners could deploy previews (secure)
- **After this revert:** Any authenticated user can deploy previews of any app (potential IDOR)

## Security Consideration
**This revert re-introduces the IDOR vulnerability that PR #304 fixed.** Without documented justification, this change should be carefully reviewed.

If there was a legitimate reason for this revert (e.g., breaking functionality), that should be documented here along with a plan to re-implement the security fix properly.

---
Reverts cloudflare/vibesdk#304