### PR TITLE
Nightly -> Main

### DIFF
--- a/worker/agents/core/websocket.ts
+++ b/worker/agents/core/websocket.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../../logger';
 import { WebSocketMessageRequests, WebSocketMessageResponses } from '../constants';
 import { WebSocketMessage, WebSocketMessageData, WebSocketMessageType } from '../../api/websocketTypes';
 import { MAX_IMAGES_PER_MESSAGE, MAX_IMAGE_SIZE_BYTES } from '../../types/image-attachment';
-import { credentialsToRuntimeOverrides, type CredentialsPayload } from '../inferutils/config.types';
+// import { credentialsToRuntimeOverrides, type CredentialsPayload } from '../inferutils/config.types';
 import type { CodeGeneratorAgent } from './codingAgent';
 
 const logger = createLogger('CodeGeneratorWebSocket');
@@ -19,8 +19,9 @@ export function handleWebSocketMessage(
 
         switch (parsedMessage.type) {
             case WebSocketMessageRequests.SESSION_INIT: {
-                const credentials = parsedMessage.credentials as CredentialsPayload | undefined;
-                agent.getBehavior().setRuntimeOverrides(credentialsToRuntimeOverrides(credentials));
+                // const credentials = parsedMessage.credentials as CredentialsPayload | undefined;
+                // agent.getBehavior().setRuntimeOverrides(credentialsToRuntimeOverrides(credentials));
+                logger.info(`Received session init message from ${connection.id}, Disable for now`);
                 break;
             }
             case WebSocketMessageRequests.GENERATE_ALL:


### PR DESCRIPTION
## Summary
This PR merges changes from the nightly branch to main, focusing on improvements to the AI Gateway credential handling logic and temporarily disabling session init credential processing.

## Changes
- **worker/agents/core/websocket.ts**: Temporarily disabled session init credential processing in WebSocket handler (commented out `setRuntimeOverrides` call)
- **worker/agents/inferutils/core.ts**: 
  - Removed commented-out code for user BYOK (Bring Your Own Key) retrieval from secrets service
  - Fixed credential isolation logic: custom gateway URLs now only use user-provided tokens, preventing accidental use of platform tokens with user gateways

## Motivation
Ensures proper credential isolation when users configure custom AI Gateway URLs. Previously, platform tokens could be used with user-provided gateway URLs, which is a security/credential boundary issue. This change ensures:
- User's custom gateway = user's credentials only
- Platform gateway = can use platform tokens as fallback

## Testing
- Verify AI inference calls work correctly with platform gateway
- Test custom AI Gateway URL configuration to ensure only user tokens are used
- Confirm session init messages are logged but credentials are not applied (intentionally disabled)

## Breaking Changes
- Session init credential processing is temporarily disabled - this may affect BYOK workflows