### PR TITLE
Fix: standardize app data access patterns

### DIFF
--- a/worker/api/controllers/apps/controller.ts
+++ b/worker/api/controllers/apps/controller.ts
@@ -87,10 +87,15 @@ export class AppController extends BaseController {
                 return AppController.createErrorResponse<FavoriteToggleData>('App ID is required', 400);
             }
 
-            // Check if app exists (no ownership check needed - users can bookmark any app)
+            // Check if app exists and get ownership/visibility info
             const ownershipResult = await appService.checkAppOwnership(appId, user.id);
-            
+
             if (!ownershipResult.exists) {
+                return AppController.createErrorResponse<FavoriteToggleData>('App not found', 404);
+            }
+
+            // Authorization: only allow favorite if user owns the app OR app is public
+            if (!ownershipResult.isOwner && ownershipResult.visibility !== 'public') {
                 return AppController.createErrorResponse<FavoriteToggleData>('App not found', 404);
             }
 

--- a/worker/database/types.ts
+++ b/worker/database/types.ts
@@ -118,6 +118,7 @@ export interface PublicAppQueryOptions extends BaseAppQueryOptions {
 export interface OwnershipResult {
     exists: boolean;
     isOwner: boolean;
+    visibility?: 'private' | 'public' | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR standardizes app data access patterns by adding proper authorization checks and sensitive data filtering for the favorite apps feature.

## Changes
- **Authorization enforcement**: Added visibility check in `toggleFavorite` controller - users can now only favorite apps they own OR public apps (previously allowed favoriting any app including private ones)
- **Data filtering in `getFavoriteAppsOnly`**: 
  - Added SQL-level authorization filter to only return public apps or user's own apps
  - Strips sensitive fields (`sessionToken`, `originalPrompt`, `finalPrompt`, GitHub repo info) from response
- **Extended `checkAppOwnership`**: Returns visibility status alongside ownership info to enable proper authorization checks
- **Type update**: Added optional `visibility` field to `OwnershipResult` interface

## Motivation
Security improvement to prevent unauthorized access to private app data through the favorites feature. Before this change:
1. Users could favorite any app (including private apps they shouldn't access)
2. Favorited apps list could leak sensitive fields from apps the user shouldn't see

## Testing
- Verify users can still favorite their own apps (public or private)
- Verify users can favorite other users' public apps
- Verify users cannot favorite other users' private apps (should get 404)
- Verify favorited apps list only shows authorized apps with sensitive fields stripped

## Breaking Changes
None - this is a security fix that tightens existing behavior.

## Related Issues
None identified