### PR TITLE
Release: Nightly -> Demo (build.cloudflare.dev)

### DIFF
--- a/worker/api/controllers/apps/controller.ts
+++ b/worker/api/controllers/apps/controller.ts
@@ -87,10 +87,15 @@ export class AppController extends BaseController {
                 return AppController.createErrorResponse<FavoriteToggleData>('App ID is required', 400);
             }
 
-            // Check if app exists (no ownership check needed - users can bookmark any app)
+            // Check if app exists and get ownership/visibility info
             const ownershipResult = await appService.checkAppOwnership(appId, user.id);
-            
+
             if (!ownershipResult.exists) {
+                return AppController.createErrorResponse<FavoriteToggleData>('App not found', 404);
+            }
+
+            // Authorization: only allow favorite if user owns the app OR app is public
+            if (!ownershipResult.isOwner && ownershipResult.visibility !== 'public') {
                 return AppController.createErrorResponse<FavoriteToggleData>('App not found', 404);
             }
 

--- a/worker/database/types.ts
+++ b/worker/database/types.ts
@@ -118,6 +118,7 @@ export interface PublicAppQueryOptions extends BaseAppQueryOptions {
 export interface OwnershipResult {
     exists: boolean;
     isOwner: boolean;
+    visibility?: 'private' | 'public' | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Security hardening for the favorites feature - adds authorization checks to prevent users from favoriting private apps they don't own, and strips sensitive fields from favorite app responses.

## Changes
- **Authorization check for favorites** (`worker/api/controllers/apps/controller.ts`): Added visibility check to `toggleFavorite` - users can only favorite apps they own OR public apps
- **Query filtering** (`worker/database/services/AppService.ts`): `getFavoriteAppsOnly` now filters to only return public apps or user's own apps
- **Sensitive field stripping** (`worker/database/services/AppService.ts`): Strips `sessionToken`, `originalPrompt`, `finalPrompt`, `githubRepositoryUrl`, and `githubRepositoryVisibility` from favorite app responses
- **Type update** (`worker/database/types.ts`): Added optional `visibility` field to `OwnershipResult` interface

## Motivation
Closes a potential information disclosure vulnerability where users could:
1. Favorite private apps they don't own (by guessing app IDs)
2. Access sensitive app metadata through the favorites endpoint

## Testing
- Verify favoriting a public app works
- Verify favoriting own private app works
- Verify favoriting another user's private app returns 404
- Verify favorite app list only shows authorized apps
- Verify sensitive fields are not exposed in favorite app responses

## Breaking Changes
None - this is a security hardening change that restricts previously allowed but unintended behavior.