### PR TITLE
Feat: implement signed URL security for screenshot access

### DIFF
--- a/worker/api/controllers/apps/controller.ts
+++ b/worker/api/controllers/apps/controller.ts
@@ -27,7 +27,7 @@ export class AppController extends BaseController {
             const userApps = await appService.getUserAppsWithFavorites(user.id);
 
             const responseData: AppsListData = {
-                apps: userApps // Already properly typed and formatted by DatabaseService
+                apps: userApps
             };
 
             return AppController.createSuccessResponse(responseData);
@@ -46,7 +46,7 @@ export class AppController extends BaseController {
             const recentApps = await appService.getRecentAppsWithFavorites(user.id, 10);
 
             const responseData: AppsListData = {
-                apps: recentApps // Already properly typed and formatted by DatabaseService
+                apps: recentApps
             };
 
             return AppController.createSuccessResponse(responseData);

--- a/worker/api/routes/imagesRoutes.ts
+++ b/worker/api/routes/imagesRoutes.ts
@@ -8,7 +8,7 @@ export function setupScreenshotRoutes(app: Hono<AppEnv>): void {
   const screenshotsRouter = new Hono<AppEnv>();
 
   // Publicly serve screenshots (they are non-sensitive previews of generated apps)
-  screenshotsRouter.get('/:id/:file', setAuthLevel(AuthConfig.authenticated), adaptController(ScreenshotsController, ScreenshotsController.serveScreenshot));
+  screenshotsRouter.get('/:id/:file', setAuthLevel(AuthConfig.public), adaptController(ScreenshotsController, ScreenshotsController.serveScreenshot));
 
   app.route('/api/screenshots', screenshotsRouter);
 

--- a/worker/api/websocketTypes.ts
+++ b/worker/api/websocketTypes.ts
@@ -264,6 +264,7 @@ type ScreenshotCaptureSuccessMessage = {
 	viewport: { width: number; height: number };
 	screenshotSize: number;
 	timestamp: string;
+	screenshotUrl?: string;
 };
 
 type ScreenshotCaptureErrorMessage = {

--- a/worker/utils/screenshot-security.ts
+++ b/worker/utils/screenshot-security.ts
@@ -1,0 +1,43 @@
+import { JWTUtils } from './jwtUtils';
+
+const SCREENSHOT_PATH_PREFIX = '/api/screenshots/';
+
+export class ScreenshotSecurity {
+    private static readonly TOKEN_EXPIRY = 6 * 60 * 60; // 6 hours
+
+    private jwt: JWTUtils;
+
+    constructor(env: { JWT_SECRET: string }) {
+        this.jwt = JWTUtils.getInstance(env);
+    }
+
+    async signUrl(url: string, appId: string): Promise<string> {
+        const isAbsolute = url.startsWith('http://') || url.startsWith('https://');
+
+        let parsed: URL;
+        try {
+            parsed = new URL(url, 'http://localhost');
+        } catch {
+            return url;
+        }
+
+        if (!parsed.pathname.startsWith(SCREENSHOT_PATH_PREFIX)) return url;
+
+        const token = await this.jwt.signPayload({ appId, purpose: 'screenshot' }, ScreenshotSecurity.TOKEN_EXPIRY);
+        parsed.searchParams.set('token', token);
+        return isAbsolute ? parsed.toString() : parsed.pathname + parsed.search;
+    }
+
+    async enrichUrls<T extends { id: string; screenshotUrl?: string | null }>(apps: T[]): Promise<T[]> {
+        return Promise.all(apps.map(async (app) => {
+            if (!app.screenshotUrl) return app;
+            const signed = await this.signUrl(app.screenshotUrl, app.id);
+            return signed === app.screenshotUrl ? app : { ...app, screenshotUrl: signed };
+        }));
+    }
+
+    async verifyToken(token: string, expectedAppId: string): Promise<boolean> {
+        const payload = await this.jwt.verifyPayload(token);
+        return payload?.appId === expectedAppId && payload?.purpose === 'screenshot';
+    }
+}


### PR DESCRIPTION
## Summary
Implements JWT-based URL signing for screenshot endpoints to prevent unauthorized enumeration and access of screenshots by external parties.

## Changes
- **New module:** `worker/utils/screenshot-security.ts` - ScreenshotSecurity class for signing and verifying screenshot URLs
- **JWT utilities:** Added generic `signPayload()` and `verifyPayload()` methods to `JWTUtils` class
- **Screenshots controller:** Added token verification before serving screenshots, returns 404 for missing/invalid tokens
- **AppService:** Added `enrichScreenshotUrls()` to automatically sign screenshot URLs when returning app data
- **Base behavior:** Signs screenshot URLs before broadcasting to WebSocket clients
- **Route config:** Changed screenshot route from `authenticated` to `public` (auth now handled by signed tokens)
- **Cache header:** Reduced max-age from 1 year to 6 hours to match token expiry

## Motivation
Previously, screenshot URLs were predictable paths (`/api/screenshots/{sessionId}/{filename}`) that could be enumerated by anyone who guessed valid session IDs. This change adds cryptographic verification to ensure only authorized parties can access screenshots.

## Testing
- Verify signed URLs work correctly when viewing app details
- Test that unsigned/tampered URLs return 404
- Ensure WebSocket screenshot capture events include signed URLs
- Check that token expiration (6 hours) behaves correctly

## Breaking Changes
- Screenshot URLs now require a `?token=` query parameter
- Existing unsigned screenshot URLs will no longer work

## Related Issues
None identified