### PR TITLE
fix: make last phase detection deterministic

### DIFF
--- a/worker/agents/core/behaviors/phasic.ts
+++ b/worker/agents/core/behaviors/phasic.ts
@@ -414,7 +414,12 @@ export class PhasicCodingBehavior extends BaseCodingBehavior<PhasicState> implem
 
             const phasesCounter = this.decrementPhasesCounter();
 
-            if ((phaseConcept.lastPhase || phasesCounter <= 0) && this.state.pendingUserInputs.length === 0) return {currentDevState: CurrentDevState.FINALIZING};
+            // Determine last phase deterministically based on roadmap completion, not LLM output
+            const completedPhasesCount = this.state.generatedPhases.filter(p => p.completed).length;
+            const roadmapLength = this.state.blueprint.implementationRoadmap?.length ?? 0;
+            const isRoadmapComplete = roadmapLength > 0 && completedPhasesCount >= roadmapLength;
+
+            if ((isRoadmapComplete || phasesCounter <= 0) && this.state.pendingUserInputs.length === 0) return {currentDevState: CurrentDevState.FINALIZING};
             return {currentDevState: CurrentDevState.PHASE_GENERATING};
         } catch (error) {
             this.logger.error("Error implementing phase", error);

--- a/worker/agents/operations/PhaseGeneration.ts
+++ b/worker/agents/operations/PhaseGeneration.ts
@@ -40,10 +40,7 @@ const SYSTEM_PROMPT = `<ROLE>
 
     Plan the phase name and description appropriately. They don't have to strictly adhere to the blueprint's roadmap as unforeseen issues may occur.
     
-    Plan the next phase to advance toward completion. Set lastPhase: true when:
-    - The blueprint's implementation roadmap is complete
-    - All core features are working
-    - No critical runtime errors remain
+    Plan the next phase to advance toward completion. The system will automatically determine when the roadmap is complete based on implemented phases.
 
     Do not add phases for polish, optimization, or hypothetical improvements - users can request those via feedback.
     Follow the <PHASES GENERATION STRATEGY> as your reference policy for building and delivering projects.


### PR DESCRIPTION
## Summary
Make the last phase detection deterministic by basing it on roadmap completion progress rather than relying on the LLM's `lastPhase` output flag.

## Changes
- Modified `worker/agents/core/behaviors/phasic.ts` to calculate `isRoadmapComplete` based on the count of completed phases versus the implementation roadmap length
- Simplified the system prompt in `worker/agents/operations/PhaseGeneration.ts` by removing instructions for the LLM to set `lastPhase: true`, since the system now handles this automatically

## Motivation
Previously, the system relied on the LLM to output `lastPhase: true` when it determined the roadmap was complete. This approach was non-deterministic because LLM outputs can vary. By calculating roadmap completion based on the actual number of completed phases compared to the roadmap length, the behavior becomes predictable and consistent.

## Testing
- Verify that phases complete correctly when `completedPhasesCount >= roadmapLength`
- Verify that the system continues generating phases when the roadmap is not complete
- Verify edge case: when `roadmapLength` is 0, the fallback to `phasesCounter <= 0` still works

## Breaking Changes
None - this is an internal implementation change that should not affect external behavior.