### PR TITLE
Nightly -> Main

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"knip:exports": "knip --exports"
 	},
 	"dependencies": {
+		"acorn": "^8.14.0",
 		"@ashishkumar472/cf-git": "1.0.5",
 		"@babel/generator": "^7.28.5",
 		"@babel/parser": "^7.28.5",
@@ -100,6 +101,7 @@
 		"framer-motion": "^12.23.26",
 		"hash-wasm": "^4.12.0",
 		"hono": "^4.11.0",
+		"htmlparser2": "^10.0.0",
 		"html2canvas-pro": "^1.5.13",
 		"input-otp": "^1.4.2",
 		"inquirer": "^12.11.1",

--- a/worker/agents/core/behaviors/base.ts
+++ b/worker/agents/core/behaviors/base.ts
@@ -42,6 +42,7 @@ import type { DeepDebuggerInputs } from '../../operations/DeepDebugger';
 import { generatePortToken } from 'worker/utils/cryptoUtils';
 import { getPreviewDomain, getProtocolForHost } from 'worker/utils/urls';
 import { isDev } from 'worker/utils/envs';
+import { InMemoryAnalyzer } from '../../../services/static-analysis';
 
 // Screenshot capture configuration
 const SCREENSHOT_CONFIG = {
@@ -589,13 +590,25 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
      */
     async runStaticAnalysisCode(files?: string[]): Promise<StaticAnalysisResponse> {
         try {
-            // Check if we have cached static analysis
-            if (this.staticAnalysisCache) {
+            // Only use cache for full (unscoped) analysis
+            if (!files && this.staticAnalysisCache) {
                 return this.staticAnalysisCache;
             }
-            
-            const analysisResponse = await this.deploymentManager.runStaticAnalysis(files);
-            this.staticAnalysisCache = analysisResponse;
+
+            // Use in-memory analysis for browser-rendered projects (no sandbox)
+            const templateDetails = this.getTemplateDetails();
+            let analysisResponse: StaticAnalysisResponse;
+
+            if (templateDetails?.renderMode === 'browser') {
+                analysisResponse = await this.runInMemoryAnalysis(files);
+            } else {
+                analysisResponse = await this.deploymentManager.runStaticAnalysis(files);
+            }
+
+            // Only cache full (unscoped) analysis results
+            if (!files) {
+                this.staticAnalysisCache = analysisResponse;
+            }
 
             const { lint, typecheck } = analysisResponse;
             this.broadcast(WebSocketMessageResponses.STATIC_ANALYSIS_RESULTS, {
@@ -608,6 +621,26 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             this.broadcastError("Failed to lint code", error);
             return { success: false, lint: { issues: [], }, typecheck: { issues: [], } };
         }
+    }
+
+    /**
+     * Run in-memory static analysis for browser-rendered projects
+     * Performs static analysis directly in the worker without using the sandbox
+     */
+    private async runInMemoryAnalysis(filePaths?: string[]): Promise<StaticAnalysisResponse> {
+        const allFiles = this.fileManager.getAllFiles();
+        const filePathSet = filePaths ? new Set(filePaths) : null;
+        const filesToAnalyze = filePathSet
+            ? allFiles.filter((f) => filePathSet.has(f.filePath))
+            : allFiles;
+
+        const fileInputs = filesToAnalyze.map((f) => ({
+            path: f.filePath,
+            content: f.fileContents,
+        }));
+
+        const analyzer = new InMemoryAnalyzer();
+        return analyzer.analyze(fileInputs);
     }
 
     /**
@@ -685,8 +718,14 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
     }
 
     async fetchAllIssues(resetIssues: boolean = false): Promise<AllIssues> {
-        if (!this.state.sandboxInstanceId) {
-            return { runtimeErrors: [], staticAnalysis: { success: false, lint: { issues: [], }, typecheck: { issues: [], } } };
+        const templateDetails = this.getTemplateDetails();
+        const isBrowserOnly = templateDetails?.renderMode === 'browser';
+
+        // For browser-rendered projects (no sandbox), only run static analysis
+        if (isBrowserOnly) {
+            const staticAnalysis = await this.runStaticAnalysisCode();
+            this.logger.info("Fetched issues (browser-rendered):", JSON.stringify({ runtimeErrors: [], staticAnalysis }));
+            return { runtimeErrors: [], staticAnalysis };
         }
         const [runtimeErrors, staticAnalysis] = await Promise.all([
             this.fetchRuntimeErrors(resetIssues),

--- a/worker/agents/prompts.ts
+++ b/worker/agents/prompts.ts
@@ -119,9 +119,23 @@ and provide a preview url for the application.
         }
     },
 
-    serializeStaticAnalysis(staticAnalysis: StaticAnalysisResponse): string {
-        const lintOutput = staticAnalysis.lint?.rawOutput || 'No linting issues detected';
-        const typecheckOutput = staticAnalysis.typecheck?.rawOutput || 'No type checking issues detected';
+    serializeStaticAnalysis(staticAnalysis: StaticAnalysisResponse, maxIssues = 20): string {
+        const formatIssues = (issues: typeof staticAnalysis.lint.issues): string => {
+            if (issues.length === 0) {
+                return 'No issues detected';
+            }
+            const limitedIssues = issues.slice(0, maxIssues);
+            const formatted = limitedIssues.map(issue => 
+                `- [${issue.severity}] ${issue.filePath}:${issue.line}:${issue.column} - ${issue.message} (${issue.ruleId})`
+            ).join('\n');
+            if (issues.length > maxIssues) {
+                return `${formatted}\n... and ${issues.length - maxIssues} more issues (truncated)`;
+            }
+            return formatted;
+        };
+
+        const lintOutput = staticAnalysis.lint.rawOutput || formatIssues(staticAnalysis.lint.issues);
+        const typecheckOutput = staticAnalysis.typecheck.rawOutput || formatIssues(staticAnalysis.typecheck.issues);
         
         return `**LINT ANALYSIS:**
 ${lintOutput}

--- a/worker/services/static-analysis/InMemoryAnalyzer.ts
+++ b/worker/services/static-analysis/InMemoryAnalyzer.ts
@@ -1,0 +1,84 @@
+import type { IStaticAnalyzer, LanguageAnalyzer, CrossFileValidator, FileInput, StaticAnalysisResponse, CodeIssue } from './types';
+import { JavaScriptAnalyzer } from './analyzers/JavaScriptAnalyzer';
+import { HTMLAnalyzer } from './analyzers/HTMLAnalyzer';
+import { CSSAnalyzer } from './analyzers/CSSAnalyzer';
+import { HTMLCSSCrossValidator } from './validators/HTMLCSSCrossValidator';
+
+export class InMemoryAnalyzer implements IStaticAnalyzer {
+	private analyzers: LanguageAnalyzer[];
+	private crossValidators: CrossFileValidator[];
+
+	constructor() {
+		this.analyzers = [
+			new JavaScriptAnalyzer(),
+			new HTMLAnalyzer(),
+			new CSSAnalyzer(),
+		];
+		this.crossValidators = [
+			new HTMLCSSCrossValidator(),
+		];
+	}
+
+	async analyze(files: FileInput[]): Promise<StaticAnalysisResponse> {
+		const allIssues: CodeIssue[] = [];
+
+		// Single-file analysis
+		for (const file of files) {
+			const analyzer = this.getAnalyzerForFile(file.path);
+			if (analyzer) {
+				const issues = analyzer.analyze(file);
+				allIssues.push(...issues);
+			}
+		}
+
+		// Cross-file validation
+		for (const validator of this.crossValidators) {
+			const issues = validator.validate(files);
+			allIssues.push(...issues);
+		}
+
+		return this.buildResponse(allIssues);
+	}
+
+	private getAnalyzerForFile(filePath: string): LanguageAnalyzer | null {
+		const ext = this.getExtension(filePath);
+		for (const analyzer of this.analyzers) {
+			if (analyzer.supportedExtensions.includes(ext)) {
+				return analyzer;
+			}
+		}
+		return null;
+	}
+
+	private getExtension(filePath: string): string {
+		const lastDot = filePath.lastIndexOf('.');
+		if (lastDot === -1) return '';
+		return filePath.slice(lastDot).toLowerCase();
+	}
+
+	private buildResponse(issues: CodeIssue[]): StaticAnalysisResponse {
+		const errorCount = issues.filter((i) => i.severity === 'error').length;
+		const warningCount = issues.filter((i) => i.severity === 'warning').length;
+		const infoCount = issues.filter((i) => i.severity === 'info').length;
+
+		return {
+			success: true,
+			lint: {
+				issues,
+				summary: {
+					errorCount,
+					warningCount,
+					infoCount,
+				},
+			},
+			typecheck: {
+				issues: [],
+				summary: {
+					errorCount: 0,
+					warningCount: 0,
+					infoCount: 0,
+				},
+			},
+		};
+	}
+}

--- a/worker/services/static-analysis/analyzers/CSSAnalyzer.ts
+++ b/worker/services/static-analysis/analyzers/CSSAnalyzer.ts
@@ -1,0 +1,105 @@
+import type { LanguageAnalyzer, FileInput, CodeIssue } from '../types';
+
+export class CSSAnalyzer implements LanguageAnalyzer {
+	readonly supportedExtensions = ['.css'];
+
+	analyze(file: FileInput): CodeIssue[] {
+		const issues: CodeIssue[] = [];
+		const content = file.content;
+		const lines = content.split('\n');
+
+		let braceCount = 0;
+		let inString = false;
+		let stringChar = '';
+		let inComment = false;
+
+		for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+			const line = lines[lineNum];
+
+			for (let i = 0; i < line.length; i++) {
+				const char = line[i];
+				const nextChar = line[i + 1];
+
+				// Handle comments
+				if (!inString && !inComment && char === '/' && nextChar === '*') {
+					inComment = true;
+					i++;
+					continue;
+				}
+				if (inComment && char === '*' && nextChar === '/') {
+					inComment = false;
+					i++;
+					continue;
+				}
+				if (inComment) continue;
+
+				// Handle strings
+				if (!inString && (char === '"' || char === "'")) {
+					inString = true;
+					stringChar = char;
+					continue;
+				}
+				if (inString && char === stringChar && line[i - 1] !== '\\') {
+					inString = false;
+					continue;
+				}
+				if (inString) continue;
+
+				// Count braces
+				if (char === '{') braceCount++;
+				if (char === '}') braceCount--;
+
+				if (braceCount < 0) {
+					issues.push({
+						message: 'Unexpected closing brace',
+						filePath: file.path,
+						line: lineNum + 1,
+						column: i,
+						severity: 'error',
+						ruleId: 'CSS_UNEXPECTED_BRACE',
+						source: 'css-analyzer',
+					});
+					braceCount = 0;
+				}
+			}
+		}
+
+		if (braceCount > 0) {
+			issues.push({
+				message: `Unclosed brace: ${braceCount} opening brace(s) without matching close`,
+				filePath: file.path,
+				line: lines.length,
+				column: 0,
+				severity: 'error',
+				ruleId: 'CSS_UNCLOSED_BRACE',
+				source: 'css-analyzer',
+			});
+		}
+
+		if (inComment) {
+			issues.push({
+				message: 'Unclosed comment',
+				filePath: file.path,
+				line: lines.length,
+				column: 0,
+				severity: 'error',
+				ruleId: 'CSS_UNCLOSED_COMMENT',
+				source: 'css-analyzer',
+			});
+		}
+
+		if (inString) {
+			issues.push({
+				message: 'Unclosed string',
+				filePath: file.path,
+				line: lines.length,
+				column: 0,
+				severity: 'error',
+				ruleId: 'CSS_UNCLOSED_STRING',
+				source: 'css-analyzer',
+			});
+		}
+
+		return issues;
+	}
+}

--- a/worker/services/static-analysis/analyzers/HTMLAnalyzer.ts
+++ b/worker/services/static-analysis/analyzers/HTMLAnalyzer.ts
@@ -1,0 +1,98 @@
+import { Parser } from 'htmlparser2';
+import type { LanguageAnalyzer, FileInput, CodeIssue } from '../types';
+
+export class HTMLAnalyzer implements LanguageAnalyzer {
+	readonly supportedExtensions = ['.html', '.htm'];
+
+	analyze(file: FileInput): CodeIssue[] {
+		const issues: CodeIssue[] = [];
+		const tagStack: Array<{ name: string; line: number }> = [];
+		let currentLine = 1;
+
+		const selfClosingTags = new Set([
+			'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+			'link', 'meta', 'param', 'source', 'track', 'wbr',
+		]);
+
+		const parser = new Parser(
+			{
+				onopentag: (name: string, _attribs: Record<string, string>) => {
+					if (!selfClosingTags.has(name.toLowerCase())) {
+						tagStack.push({ name: name.toLowerCase(), line: currentLine });
+					}
+				},
+				onclosetag: (name: string) => {
+					const lowerName = name.toLowerCase();
+					if (selfClosingTags.has(lowerName)) return;
+
+					if (tagStack.length === 0) {
+						issues.push({
+							message: `Unexpected closing tag </${name}>`,
+							filePath: file.path,
+							line: currentLine,
+							column: 0,
+							severity: 'error',
+							ruleId: 'HTML_UNEXPECTED_CLOSE',
+							source: 'htmlparser2',
+						});
+						return;
+					}
+
+					const lastTag = tagStack[tagStack.length - 1];
+					if (lastTag.name !== lowerName) {
+						issues.push({
+							message: `Mismatched closing tag: expected </${lastTag.name}>, found </${name}>`,
+							filePath: file.path,
+							line: currentLine,
+							column: 0,
+							severity: 'error',
+							ruleId: 'HTML_TAG_MISMATCH',
+							source: 'htmlparser2',
+						});
+					} else {
+						tagStack.pop();
+					}
+				},
+				ontext: (text: string) => {
+					currentLine += (text.match(/\n/g) || []).length;
+				},
+			},
+			{
+				lowerCaseTags: false,
+				lowerCaseAttributeNames: false,
+			}
+		);
+
+		try {
+			parser.write(file.content);
+			parser.end();
+		} catch (error) {
+			if (error instanceof Error) {
+				issues.push({
+					message: error.message,
+					filePath: file.path,
+					line: 1,
+					column: 0,
+					severity: 'error',
+					ruleId: 'HTML_PARSE_ERROR',
+					source: 'htmlparser2',
+				});
+			}
+		}
+
+		// Check for unclosed tags
+		for (const tag of tagStack) {
+			issues.push({
+				message: `Unclosed tag <${tag.name}>`,
+				filePath: file.path,
+				line: tag.line,
+				column: 0,
+				severity: 'error',
+				ruleId: 'HTML_UNCLOSED_TAG',
+				source: 'htmlparser2',
+			});
+		}
+
+		return issues;
+	}
+}

--- a/worker/services/static-analysis/analyzers/JavaScriptAnalyzer.ts
+++ b/worker/services/static-analysis/analyzers/JavaScriptAnalyzer.ts
@@ -1,0 +1,43 @@
+import * as acorn from 'acorn';
+import type { LanguageAnalyzer, FileInput, CodeIssue } from '../types';
+
+export class JavaScriptAnalyzer implements LanguageAnalyzer {
+	readonly supportedExtensions = ['.js', '.mjs'];
+
+	analyze(file: FileInput): CodeIssue[] {
+		const issues: CodeIssue[] = [];
+
+		try {
+			acorn.parse(file.content, {
+				ecmaVersion: 'latest',
+				sourceType: 'module',
+				locations: true,
+			});
+		} catch (error: unknown) {
+			if (error instanceof SyntaxError) {
+				const acornError = error as SyntaxError & { loc?: { line: number; column: number } };
+				issues.push({
+					message: acornError.message,
+					filePath: file.path,
+					line: acornError.loc?.line ?? 1,
+					column: acornError.loc?.column ?? 0,
+					severity: 'error',
+					ruleId: 'JS_SYNTAX_ERROR',
+					source: 'acorn',
+				});
+			} else if (error instanceof Error) {
+				issues.push({
+					message: error.message,
+					filePath: file.path,
+					line: 1,
+					column: 0,
+					severity: 'error',
+					ruleId: 'JS_PARSE_ERROR',
+					source: 'acorn',
+				});
+			}
+		}
+
+		return issues;
+	}
+}

--- a/worker/services/static-analysis/analyzers/index.ts
+++ b/worker/services/static-analysis/analyzers/index.ts
@@ -1,0 +1,3 @@
+export { JavaScriptAnalyzer } from './JavaScriptAnalyzer';
+export { HTMLAnalyzer } from './HTMLAnalyzer';
+export { CSSAnalyzer } from './CSSAnalyzer';

--- a/worker/services/static-analysis/index.ts
+++ b/worker/services/static-analysis/index.ts
@@ -1,0 +1,5 @@
+export { InMemoryAnalyzer } from './InMemoryAnalyzer';
+export { JavaScriptAnalyzer } from './analyzers/JavaScriptAnalyzer';
+export { HTMLAnalyzer } from './analyzers/HTMLAnalyzer';
+export { CSSAnalyzer } from './analyzers/CSSAnalyzer';
+export type { IStaticAnalyzer, LanguageAnalyzer, FileInput } from './types';

--- a/worker/services/static-analysis/types.ts
+++ b/worker/services/static-analysis/types.ts
@@ -1,0 +1,21 @@
+import type { CodeIssue, StaticAnalysisResponse, LintSeverity } from '../sandbox/sandboxTypes';
+
+export interface FileInput {
+	path: string;
+	content: string;
+}
+
+export interface IStaticAnalyzer {
+	analyze(files: FileInput[]): Promise<StaticAnalysisResponse>;
+}
+
+export interface LanguageAnalyzer {
+	readonly supportedExtensions: string[];
+	analyze(file: FileInput): CodeIssue[];
+}
+
+export interface CrossFileValidator {
+	validate(files: FileInput[]): CodeIssue[];
+}
+
+export type { CodeIssue, StaticAnalysisResponse, LintSeverity };

--- a/worker/services/static-analysis/validators/HTMLCSSCrossValidator.ts
+++ b/worker/services/static-analysis/validators/HTMLCSSCrossValidator.ts
@@ -1,0 +1,209 @@
+import { Parser } from 'htmlparser2';
+import type { CrossFileValidator, FileInput, CodeIssue } from '../types';
+
+interface CSSUsage {
+	name: string;
+	type: 'class' | 'id';
+	filePath: string;
+	line: number;
+}
+
+const DYNAMIC_CLASS_PATTERNS = [
+	/^{{.*}}$/,
+	/^<%.*%>$/,
+	/^\$\{.*\}$/,
+	/^\[.*\]$/,
+	/^:.*$/,
+	/^v-/,
+	/^ng-/,
+	/^x-/,
+];
+
+const UTILITY_FRAMEWORK_PATTERNS = [
+	/^-?[mpwh][trblxy]?-/,
+	/^(flex|grid|block|inline|hidden|visible|absolute|relative|fixed|sticky)/,
+	/^(text|bg|border|rounded|shadow|opacity|z)-/,
+	/^(sm|md|lg|xl|2xl):/,
+	/^(hover|focus|active|disabled|dark):/,
+	/^(justify|items|content|self)-/,
+	/^(gap|space)-/,
+	/^(font|leading|tracking)-/,
+	/^(overflow|cursor|pointer|transition|duration|ease)-/,
+];
+
+function isLikelyDynamicOrFrameworkClass(className: string): boolean {
+	for (const pattern of DYNAMIC_CLASS_PATTERNS) {
+		if (pattern.test(className)) return true;
+	}
+	for (const pattern of UTILITY_FRAMEWORK_PATTERNS) {
+		if (pattern.test(className)) return true;
+	}
+	return false;
+}
+
+export class HTMLCSSCrossValidator implements CrossFileValidator {
+	validate(files: FileInput[]): CodeIssue[] {
+		const definedClasses = new Set<string>();
+		const definedIds = new Set<string>();
+		const usedSelectors: CSSUsage[] = [];
+
+		// Extract CSS definitions from .css files and inline <style> tags
+		for (const file of files) {
+			if (file.path.endsWith('.css')) {
+				this.extractCSSDefinitions(file.content, definedClasses, definedIds);
+			}
+			if (file.path.endsWith('.html') || file.path.endsWith('.htm')) {
+				this.extractInlineStyles(file.content, definedClasses, definedIds);
+			}
+		}
+
+		// Extract CSS usage from HTML files
+		for (const file of files) {
+			if (file.path.endsWith('.html') || file.path.endsWith('.htm')) {
+				const usage = this.extractHTMLUsage(file);
+				usedSelectors.push(...usage);
+			}
+		}
+
+		// Find undefined selectors
+		const issues: CodeIssue[] = [];
+		for (const usage of usedSelectors) {
+			if (usage.type === 'class' && !definedClasses.has(usage.name)) {
+				if (isLikelyDynamicOrFrameworkClass(usage.name)) continue;
+				issues.push({
+					message: `CSS class "${usage.name}" is used but not defined in any CSS file`,
+					filePath: usage.filePath,
+					line: usage.line,
+					column: 0,
+					severity: 'warning',
+					ruleId: 'CSS_CLASS_UNDEFINED',
+					source: 'html-css-validator',
+				});
+			}
+			if (usage.type === 'id' && !definedIds.has(usage.name)) {
+				issues.push({
+					message: `CSS ID "${usage.name}" is used but not defined in any CSS file`,
+					filePath: usage.filePath,
+					line: usage.line,
+					column: 0,
+					severity: 'warning',
+					ruleId: 'CSS_ID_UNDEFINED',
+					source: 'html-css-validator',
+				});
+			}
+		}
+
+		return issues;
+	}
+
+	private extractCSSDefinitions(
+		content: string,
+		classes: Set<string>,
+		ids: Set<string>
+	): void {
+		// Strip comments
+		let cleaned = content.replace(/\/\*[\s\S]*?\*\//g, '');
+
+		// Strip url(...) values to avoid matching dots in URLs
+		cleaned = cleaned.replace(/url\s*\([^)]*\)/gi, '');
+
+		// Extract only selector portions (text before each {)
+		const selectorBlocks: string[] = [];
+		let depth = 0;
+		let currentSelector = '';
+
+		for (let i = 0; i < cleaned.length; i++) {
+			const char = cleaned[i];
+			if (char === '{') {
+				if (depth === 0) {
+					selectorBlocks.push(currentSelector);
+					currentSelector = '';
+				}
+				depth++;
+			} else if (char === '}') {
+				depth--;
+			} else if (depth === 0) {
+				currentSelector += char;
+			}
+		}
+
+		// Parse selectors from the extracted selector blocks
+		const selectorText = selectorBlocks.join(' ');
+
+		// Match class selectors: .classname (must start with letter, underscore, or hyphen)
+		const classRegex = /\.([a-zA-Z_][a-zA-Z0-9_-]*)/g;
+		let match;
+		while ((match = classRegex.exec(selectorText)) !== null) {
+			classes.add(match[1]);
+		}
+
+		// Match ID selectors: #idname (must start with letter or underscore, not digit)
+		const idRegex = /#([a-zA-Z_][a-zA-Z0-9_-]*)/g;
+		while ((match = idRegex.exec(selectorText)) !== null) {
+			ids.add(match[1]);
+		}
+	}
+
+	private extractInlineStyles(
+		htmlContent: string,
+		classes: Set<string>,
+		ids: Set<string>
+	): void {
+		// Extract content from <style> tags
+		const styleRegex = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+		let match;
+		while ((match = styleRegex.exec(htmlContent)) !== null) {
+			this.extractCSSDefinitions(match[1], classes, ids);
+		}
+	}
+
+	private extractHTMLUsage(file: FileInput): CSSUsage[] {
+		const usage: CSSUsage[] = [];
+		let currentLine = 1;
+
+		const parser = new Parser(
+			{
+				onopentag: (_name: string, attribs: Record<string, string>) => {
+					// Extract class usage
+					if (attribs.class) {
+						const classNames = attribs.class.split(/\s+/).filter(Boolean);
+						for (const className of classNames) {
+							usage.push({
+								name: className,
+								type: 'class',
+								filePath: file.path,
+								line: currentLine,
+							});
+						}
+					}
+
+					// Extract id usage
+					if (attribs.id) {
+						usage.push({
+							name: attribs.id,
+							type: 'id',
+							filePath: file.path,
+							line: currentLine,
+						});
+					}
+				},
+				ontext: (text: string) => {
+					currentLine += (text.match(/\n/g) || []).length;
+				},
+			},
+			{
+				lowerCaseTags: false,
+				lowerCaseAttributeNames: true,
+			}
+		);
+
+		try {
+			parser.write(file.content);
+			parser.end();
+		} catch {
+			// Ignore parse errors - HTMLAnalyzer will catch them
+		}
+
+		return usage;
+	}
+}

--- a/worker/services/static-analysis/validators/index.ts
+++ b/worker/services/static-analysis/validators/index.ts
@@ -1,0 +1,1 @@
+export { HTMLCSSCrossValidator } from './HTMLCSSCrossValidator';


### PR DESCRIPTION
## Summary
Adds in-memory static analysis for browser-rendered projects that don't use a sandbox environment, enabling lint-like checks for HTML, CSS, and JavaScript files without requiring external tooling.

## Changes
- Added new `worker/services/static-analysis/` service with modular architecture:
  - `InMemoryAnalyzer`: Main orchestrator for running analysis
  - `JavaScriptAnalyzer`: Syntax checking using acorn parser
  - `HTMLAnalyzer`: Tag matching and structure validation using htmlparser2
  - `CSSAnalyzer`: Brace/comment/string balance checking
  - `HTMLCSSCrossValidator`: Cross-file validation for undefined CSS classes/IDs
- Modified `worker/agents/core/behaviors/base.ts`:
  - Updated `runStaticAnalysisCode()` to use in-memory analysis for browser-rendered projects
  - Fixed caching logic to only cache full (unscoped) analysis results
  - Updated `fetchAllIssues()` to handle browser-rendered projects without sandbox
- Enhanced `worker/agents/prompts.ts`:
  - Improved `serializeStaticAnalysis()` to format issues when `rawOutput` is not available
  - Added truncation support with configurable `maxIssues` parameter
- Added new dependencies: `acorn` and `htmlparser2` for parsing

## Motivation
Browser-rendered projects (e.g., pure HTML/CSS/JS) don't use a sandbox environment, so the existing static analysis pipeline that relies on sandbox tooling was not available. This change provides lightweight, in-memory static analysis that can catch common issues like syntax errors, unclosed tags, and undefined CSS selectors.

## Testing
- Test browser-rendered projects to verify static analysis runs correctly
- Verify that sandbox-based projects continue to use the existing analysis pipeline
- Test edge cases: malformed HTML, CSS with unclosed braces, JS syntax errors
- Verify cross-file CSS validation catches undefined classes/IDs

## Breaking Changes
None - this is an additive change that only affects browser-rendered projects.