### PR TITLE
feat: faster blueprint for minimal templates

### DIFF
--- a/worker/agents/schemas.ts
+++ b/worker/agents/schemas.ts
@@ -114,6 +114,19 @@ export const PhasicBlueprintSchema = SimpleBlueprintSchema.extend({
     initialPhase: PhaseConceptSchema.describe('The first phase to be implemented, in **STRICT** accordance with <PHASE GENERATION STRATEGY>'),
 });
 
+export const LitePhasicBlueprintSchema = SimpleBlueprintSchema.extend({
+    detailedDescription: z.string().describe('2-3 sentence description of what the application does and how it works'),
+    views: z.array(z.object({
+        name: z.string().describe('Name of the view'),
+        description: z.string().describe('One-sentence description of the view'),
+    })).describe('Views of the application'),
+    userFlow: z.string().describe('Concise description of UI layout, design, and user journey in one paragraph'),
+    dataFlow: z.string().describe('Brief description of how data flows through the application'),
+    pitfalls: z.array(z.string()).describe('Max 5 domain-specific pitfalls, one line each'),
+    frameworks: z.array(z.string()).describe('Essential frameworks and dependencies (apart from template), major versions only'),
+    initialPhase: PhaseConceptSchema.describe('The first phase to be implemented, in **STRICT** accordance with <PHASE GENERATION STRATEGY>'),
+});
+
 export const AgenticBlueprintSchema = SimpleBlueprintSchema.extend({
     plan: z.array(z.string()).describe('Step by step plan for implementing the project'),
 });
@@ -139,6 +152,7 @@ export const ScreenshotAnalysisSchema = z.object({
 
 export type TemplateSelection = z.infer<typeof TemplateSelectionSchema>;
 export type PhasicBlueprint = z.infer<typeof PhasicBlueprintSchema>;
+export type LitePhasicBlueprint = z.infer<typeof LitePhasicBlueprintSchema>;
 export type AgenticBlueprint = z.infer<typeof AgenticBlueprintSchema>;
 export type FileConceptType = z.infer<typeof FileConceptSchema>;
 export type PhaseConceptType = z.infer<typeof PhaseConceptSchema>;


### PR DESCRIPTION
## Summary
Introduces a lightweight blueprint generation mode for minimal templates to improve performance and reduce LLM inference costs.

## Changes
- Added `LitePhasicBlueprintSchema` with simplified fields (condensed userFlow, max 5 pitfalls, shorter descriptions)
- Created `LITE_PHASIC_SYSTEM_PROMPT` optimized for rapid prototyping (~800 word limit)
- Added `liteToPhasicBlueprint()` conversion function to maintain compatibility with existing code
- Auto-detects minimal templates via name matching and routes to lite blueprint path

## Motivation
Minimal templates don't require the full verbose blueprint generation. This optimization:
- Reduces token usage and inference time for simple projects
- Produces more focused, concise blueprints proportional to project complexity
- Maintains full compatibility by converting lite blueprints to standard format

## Testing
- Test with a minimal template (e.g., `minimal-react`) and verify blueprint generation completes faster
- Verify the generated blueprint converts correctly to `PhasicBlueprint` format
- Ensure non-minimal templates still use the full `PHASIC_SYSTEM_PROMPT`

## Breaking Changes
None - the lite blueprint is converted to full `PhasicBlueprint` before returning, maintaining API compatibility.