### PR TITLE
Nightly -> main

### DIFF
--- a/worker/agents/schemas.ts
+++ b/worker/agents/schemas.ts
@@ -114,6 +114,19 @@ export const PhasicBlueprintSchema = SimpleBlueprintSchema.extend({
     initialPhase: PhaseConceptSchema.describe('The first phase to be implemented, in **STRICT** accordance with <PHASE GENERATION STRATEGY>'),
 });
 
+export const LitePhasicBlueprintSchema = SimpleBlueprintSchema.extend({
+    detailedDescription: z.string().describe('2-3 sentence description of what the application does and how it works'),
+    views: z.array(z.object({
+        name: z.string().describe('Name of the view'),
+        description: z.string().describe('One-sentence description of the view'),
+    })).describe('Views of the application'),
+    userFlow: z.string().describe('Concise description of UI layout, design, and user journey in one paragraph'),
+    dataFlow: z.string().describe('Brief description of how data flows through the application'),
+    pitfalls: z.array(z.string()).describe('Max 5 domain-specific pitfalls, one line each'),
+    frameworks: z.array(z.string()).describe('Essential frameworks and dependencies (apart from template), major versions only'),
+    initialPhase: PhaseConceptSchema.describe('The first phase to be implemented, in **STRICT** accordance with <PHASE GENERATION STRATEGY>'),
+});
+
 export const AgenticBlueprintSchema = SimpleBlueprintSchema.extend({
     plan: z.array(z.string()).describe('Step by step plan for implementing the project'),
 });
@@ -139,6 +152,7 @@ export const ScreenshotAnalysisSchema = z.object({
 
 export type TemplateSelection = z.infer<typeof TemplateSelectionSchema>;
 export type PhasicBlueprint = z.infer<typeof PhasicBlueprintSchema>;
+export type LitePhasicBlueprint = z.infer<typeof LitePhasicBlueprintSchema>;
 export type AgenticBlueprint = z.infer<typeof AgenticBlueprintSchema>;
 export type FileConceptType = z.infer<typeof FileConceptSchema>;
 export type PhaseConceptType = z.infer<typeof PhaseConceptSchema>;


### PR DESCRIPTION
## Summary
Introduces a lightweight blueprint generation mode for minimal templates, reducing prompt complexity and output verbosity for simpler projects.

## Changes
- Added `LitePhasicBlueprintSchema` in `worker/agents/schemas.ts` - a streamlined schema with fewer fields (single `userFlow` string instead of nested object, simplified descriptions)
- Added `LITE_PHASIC_SYSTEM_PROMPT` in `worker/agents/planning/blueprint.ts` - a concise ~800 word prompt for rapid prototyping
- Added `liteToPhasicBlueprint()` conversion function to transform lite blueprints to full `PhasicBlueprint` format for downstream compatibility
- Modified `generateBlueprint()` to detect minimal templates and use the appropriate schema/prompt

## Motivation
Minimal templates don't need the full verbose blueprint with extensive UI/UX details. This reduces token usage and generation time while maintaining compatibility with the rest of the pipeline.

## Testing
- Test blueprint generation with a minimal template to verify lite mode activates
- Test non-minimal templates to ensure they still use the full phasic blueprint
- Verify the converted lite blueprint works correctly downstream

## Related Issues
None identified