### PR TITLE
Fix GitHub links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Cloudflare VibeSDK implements enterprise-grade security:
 
 - 📖 Check [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
 - 💬 Join [Cloudflare Discord](https://discord.gg/cloudflaredev)
-- 🐛 Report issues on [GitHub](https://github.com/your-org/cloudflare-vibecoding-starter-kit/issues)
+- 🐛 Report issues on [GitHub](https://github.com/cloudflare/vibesdk/issues)
 
 ---
 
@@ -526,7 +526,7 @@ Want to contribute to Cloudflare VibeSDK? Here's how:
 ### 💬 **Community**  
 - [Discord](https://discord.gg/cloudflaredev) - Real-time chat and support
 - [Community Forum](https://community.cloudflare.com/) - Technical discussions
-- [GitHub Discussions](https://github.com/your-org/cloudflare-vibecoding-starter-kit/discussions) - Feature requests and ideas
+- [GitHub Discussions](https://github.com/cloudflare/vibesdk/discussions) - Feature requests and ideas
 
 ### 🎓 **Learning Resources**
 - [Workers Learning Path](https://developers.cloudflare.com/learning-paths/workers/) - Master Workers development


### PR DESCRIPTION
Fixes two broken GitHub links in the README that referenced a placeholder repository (your-org/cloudflare-vibecoding-starter-kit). Updated both the issues and discussions links to point to the correct cloudflare/vibesdk repository.