### PR TITLE
fix: bug where preview url did not use tunnel url

### DIFF
--- a/worker/agents/services/implementations/DeploymentManager.ts
+++ b/worker/agents/services/implementations/DeploymentManager.ts
@@ -16,6 +16,7 @@ import { getSandboxService } from '../../../services/sandbox/factory';
 import { validateAndCleanBootstrapCommands } from 'worker/agents/utils/common';
 import { DeploymentTarget } from '../../core/types';
 import { BaseProjectState } from '../../core/state';
+import { resolvePreviewUrl } from '../../../utils/urls';
 
 const PER_ATTEMPT_TIMEOUT_MS = 60000;  // 60 seconds per individual attempt
 const MASTER_DEPLOYMENT_TIMEOUT_MS = 300000;  // 5 minutes total
@@ -542,7 +543,7 @@ export class DeploymentManager extends BaseAgentService<BaseProjectState> implem
 
         return {
             sandboxInstanceId: results.runId,
-            previewURL: results.previewURL,
+            previewURL: resolvePreviewUrl(results.previewURL, results.tunnelURL, this.env),
             tunnelURL: results.tunnelURL,
             redeployed: true
         };

--- a/worker/services/sandbox/sandboxSdkClient.ts
+++ b/worker/services/sandbox/sandboxSdkClient.ts
@@ -43,7 +43,7 @@ import { generateId } from '../../utils/idGenerator';
 import { ResourceProvisioner } from './resourceProvisioner';
 import { TemplateParser } from './templateParser';
 import { ResourceProvisioningResult } from './types';
-import { getPreviewDomain, migratePreviewUrl } from '../../utils/urls';
+import { getPreviewDomain, resolvePreviewUrl } from '../../utils/urls';
 import { isDev } from 'worker/utils/envs'
 import { FileTreeBuilder } from './fileTreeBuilder';
 import { DeploymentTarget } from 'worker/agents/core/types';
@@ -538,7 +538,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                         uptime: Math.floor((Date.now() - new Date(metadata.startTime).getTime()) / 1000),
                         directory: instanceId,
                         serviceDirectory: instanceId,
-                        previewURL: migratePreviewUrl(metadata.previewURL, env),
+                        previewURL: resolvePreviewUrl(metadata.previewURL, metadata.tunnelURL, env),
                         processId: metadata.processId,
                         tunnelURL: metadata.tunnelURL,
                         // Skip file tree
@@ -963,12 +963,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                         }
                     }
 
-                    if(env.USE_TUNNEL_FOR_PREVIEW) {
-                        this.logger.info('Using tunnel url instead for preview as configured', { instanceId, tunnelURL });
-                        previewURL = tunnelURL;
-                    }
-                        
-                    this.logger.info('Preview URL exposed', { instanceId, previewURL });
+                    this.logger.info('Preview URL exposed', { instanceId, previewURL, tunnelURL });
                         
                     return { previewURL, tunnelURL, processId, allocatedPort };
                 } catch (error) {
@@ -1112,7 +1107,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                 serviceDirectory: instanceId,
                 fileTree,
                 runtimeErrors: runtimeErrors.errors,
-                previewURL: migratePreviewUrl(metadata.previewURL, env),
+                previewURL: resolvePreviewUrl(metadata.previewURL, metadata.tunnelURL, env),
                 processId: metadata.processId,
                 tunnelURL: metadata.tunnelURL,
             };
@@ -1169,7 +1164,7 @@ export class SandboxSdkClient extends BaseSandboxService {
                 pending: false,
                 isHealthy,
                 message: isHealthy ? 'Instance is running normally' : 'Instance may have issues',
-                previewURL: migratePreviewUrl(metadata.previewURL, env),
+                previewURL: resolvePreviewUrl(metadata.previewURL, metadata.tunnelURL, env),
                 tunnelURL: metadata.tunnelURL,
                 processId: metadata.processId
             };

--- a/worker/utils/urls.ts
+++ b/worker/utils/urls.ts
@@ -1,3 +1,5 @@
+import { isDev } from './envs';
+
 export const getProtocolForHost = (host: string): string => {
     if (host.startsWith('localhost') || host.startsWith('127.0.0.1') || host.startsWith('0.0.0.0') || host.startsWith('::1')) {
         return 'http';
@@ -47,6 +49,22 @@ export function migratePreviewUrl(storedUrl: string | undefined, env: Env): stri
     } catch {
         return storedUrl;
     }
+}
+
+/**
+ * Resolve the correct preview URL based on environment.
+ * In tunnel mode (local dev or USE_TUNNEL_FOR_PREVIEW), returns the tunnel URL.
+ * In production, applies domain migration to the sandbox preview URL.
+ */
+export function resolvePreviewUrl(
+    previewURL: string | undefined,
+    tunnelURL: string | undefined,
+    env: Env
+): string | undefined {
+    if (isDev(env) || env.USE_TUNNEL_FOR_PREVIEW) {
+        return tunnelURL || previewURL;
+    }
+    return migratePreviewUrl(previewURL, env);
 }
 
 export function buildGitCloneUrl(env: Env, appId: string, token?: string): string {


### PR DESCRIPTION
## Summary
Fixes a bug where the preview URL was not correctly resolving to the tunnel URL in development mode or when `USE_TUNNEL_FOR_PREVIEW` is enabled.

## Changes
- Added `resolvePreviewUrl()` utility function in `worker/utils/urls.ts` that centralizes preview URL resolution logic
- Updated `sandboxSdkClient.ts` to use `resolvePreviewUrl()` instead of `migratePreviewUrl()` in 3 locations
- Updated `DeploymentManager.ts` to use `resolvePreviewUrl()` when returning deployment results
- Removed inline `USE_TUNNEL_FOR_PREVIEW` check that was only partially applied

## Motivation
Previously, the `USE_TUNNEL_FOR_PREVIEW` environment flag and local development detection were not consistently applied across all preview URL usage. This resulted in users seeing incorrect preview URLs in certain scenarios (e.g., when fetching instance state).

## Testing
- Verify preview URLs in local development resolve to tunnel URLs
- Verify `USE_TUNNEL_FOR_PREVIEW=true` causes preview URLs to resolve to tunnel URLs
- Verify production environment continues to apply domain migration correctly

## Breaking Changes
None - this is a bugfix that corrects existing behavior.