### PR TITLE
[#359] fix: race condition between instance start and static analysis

### DIFF
--- a/worker/agents/core/behaviors/base.ts
+++ b/worker/agents/core/behaviors/base.ts
@@ -1655,7 +1655,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             await this.ensureTemplateDetails();
 
             // Just fetch runtime errors
-            const errors = await this.fetchRuntimeErrors(false);
+            const errors = await this.fetchRuntimeErrors(false, false);
             const projectUpdates = await this.getAndResetProjectUpdates();
             this.logger.info('Passing context to user conversation processor', { errors, projectUpdates });
 

--- a/worker/agents/core/behaviors/base.ts
+++ b/worker/agents/core/behaviors/base.ts
@@ -81,6 +81,9 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
 
     protected staticAnalysisCache: StaticAnalysisResponse | null = null;
 
+    private sandboxReadyPromise: Promise<void>;
+    private resolveSandboxReady!: () => void;
+
     protected userModelConfigs?: Record<AgentActionKey, ModelConfig>;
     protected runtimeOverrides?: InferenceRuntimeOverrides;
     
@@ -102,11 +105,27 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
     constructor(infrastructure: AgentInfrastructure<TState>, protected projectType: ProjectType) {
         super(infrastructure);
 
+        this.sandboxReadyPromise = new Promise(resolve => { this.resolveSandboxReady = resolve; });
+        if (this.state.sandboxInstanceId) {
+            this.resolveSandboxReady();
+        }
+
         this.setState({
             ...this.state,
             behaviorType: this.getBehavior(),
             projectType: this.projectType,
         });
+    }
+
+    protected async waitForSandboxReady(timeoutMs: number = 5000): Promise<boolean> {
+        const ready = await Promise.race([
+            this.sandboxReadyPromise.then(() => true),
+            new Promise<false>(resolve => setTimeout(() => resolve(false), timeoutMs))
+        ]);
+        if (!ready) {
+            this.logger.warn(`Sandbox not ready after ${timeoutMs}ms`);
+        }
+        return ready;
     }
 
     public async initialize(
@@ -727,6 +746,9 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             this.logger.info("Fetched issues (browser-rendered):", JSON.stringify({ runtimeErrors: [], staticAnalysis }));
             return { runtimeErrors: [], staticAnalysis };
         }
+        if (!await this.waitForSandboxReady()) {
+            return { runtimeErrors: [], staticAnalysis: { success: false, lint: { issues: [] }, typecheck: { issues: [] } } };
+        }
         const [runtimeErrors, staticAnalysis] = await Promise.all([
             this.fetchRuntimeErrors(resetIssues),
             this.runStaticAnalysisCode()
@@ -1175,6 +1197,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             }
         );
 
+        this.resolveSandboxReady();
         return result;
     }
     
@@ -1632,7 +1655,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             await this.ensureTemplateDetails();
 
             // Just fetch runtime errors
-            const errors = await this.fetchRuntimeErrors(false, false);
+            const errors = await this.fetchRuntimeErrors(false);
             const projectUpdates = await this.getAndResetProjectUpdates();
             this.logger.info('Passing context to user conversation processor', { errors, projectUpdates });
 


### PR DESCRIPTION
## Summary
Fixes a race condition where static analysis fails with "No sandbox instance available" error when `fetchAllIssues()` is called before the sandbox deployment completes.

## Changes
- Added promise-based synchronization mechanism (`sandboxReadyPromise`) in `BaseCodingBehavior`
- Constructor initializes the promise and resolves immediately if `sandboxInstanceId` already exists
- New `waitForSandboxReady(timeoutMs)` method with configurable timeout (default 5s)
- `fetchAllIssues()` now waits for sandbox readiness before running analysis
- `deployToSandbox()` resolves the promise after successful deployment
- Removed unused second argument from `fetchRuntimeErrors()` call in `handleUserInput()`

## Motivation
Users deploying fresh instances were encountering "Failed to lint code: No sandbox instance available for static analysis" errors during code generation. The static analysis was racing ahead of sandbox deployment, causing the generation to get stuck in "Reviewing phase".

## Testing
- Deploy a new instance and verify code generation progresses through all phases
- Verify static analysis waits for sandbox before running
- Verify timeout behavior logs warning and returns empty analysis result
- Verify reconnection scenarios work (sandbox already exists)

## Related Issues
- Fixes #359