### PR TITLE
Remerge due to parent branch already being merged

### DIFF
--- a/worker/agents/core/behaviors/base.ts
+++ b/worker/agents/core/behaviors/base.ts
@@ -1655,7 +1655,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             await this.ensureTemplateDetails();
 
             // Just fetch runtime errors
-            const errors = await this.fetchRuntimeErrors(false);
+            const errors = await this.fetchRuntimeErrors(false, false);
             const projectUpdates = await this.getAndResetProjectUpdates();
             this.logger.info('Passing context to user conversation processor', { errors, projectUpdates });
 

--- a/worker/agents/core/behaviors/base.ts
+++ b/worker/agents/core/behaviors/base.ts
@@ -81,6 +81,9 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
 
     protected staticAnalysisCache: StaticAnalysisResponse | null = null;
 
+    private sandboxReadyPromise: Promise<void>;
+    private resolveSandboxReady!: () => void;
+
     protected userModelConfigs?: Record<AgentActionKey, ModelConfig>;
     protected runtimeOverrides?: InferenceRuntimeOverrides;
     
@@ -102,11 +105,27 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
     constructor(infrastructure: AgentInfrastructure<TState>, protected projectType: ProjectType) {
         super(infrastructure);
 
+        this.sandboxReadyPromise = new Promise(resolve => { this.resolveSandboxReady = resolve; });
+        if (this.state.sandboxInstanceId) {
+            this.resolveSandboxReady();
+        }
+
         this.setState({
             ...this.state,
             behaviorType: this.getBehavior(),
             projectType: this.projectType,
         });
+    }
+
+    protected async waitForSandboxReady(timeoutMs: number = 5000): Promise<boolean> {
+        const ready = await Promise.race([
+            this.sandboxReadyPromise.then(() => true),
+            new Promise<false>(resolve => setTimeout(() => resolve(false), timeoutMs))
+        ]);
+        if (!ready) {
+            this.logger.warn(`Sandbox not ready after ${timeoutMs}ms`);
+        }
+        return ready;
     }
 
     public async initialize(
@@ -727,6 +746,9 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             this.logger.info("Fetched issues (browser-rendered):", JSON.stringify({ runtimeErrors: [], staticAnalysis }));
             return { runtimeErrors: [], staticAnalysis };
         }
+        if (!await this.waitForSandboxReady()) {
+            return { runtimeErrors: [], staticAnalysis: { success: false, lint: { issues: [] }, typecheck: { issues: [] } } };
+        }
         const [runtimeErrors, staticAnalysis] = await Promise.all([
             this.fetchRuntimeErrors(resetIssues),
             this.runStaticAnalysisCode()
@@ -1175,6 +1197,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             }
         );
 
+        this.resolveSandboxReady();
         return result;
     }
     
@@ -1632,7 +1655,7 @@ export abstract class BaseCodingBehavior<TState extends BaseProjectState>
             await this.ensureTemplateDetails();
 
             // Just fetch runtime errors
-            const errors = await this.fetchRuntimeErrors(false, false);
+            const errors = await this.fetchRuntimeErrors(false);
             const projectUpdates = await this.getAndResetProjectUpdates();
             this.logger.info('Passing context to user conversation processor', { errors, projectUpdates });
 

--- a/worker/agents/utils/templates.ts
+++ b/worker/agents/utils/templates.ts
@@ -37,7 +37,6 @@ const emitLog = (level: "info" | "warn" | "error", rawMessage: string) => {
   }
 };
 
-// 3. Create the custom logger for Vite
 const customLogger = {
   warnOnce: (msg: string) => emitLog("warn", msg),
 
@@ -97,33 +96,74 @@ export default ({ mode }: { mode: string }) => {
 
 `;
 
+const SCRATCH_PACKAGE_JSON = `{
+  "name": "scratch-project",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port \${PORT:-8001}",
+    "build": "vite build",
+    "lint": "eslint --cache -f json --quiet .",
+    "preview": "bun run build && vite preview --host 0.0.0.0 --port \${PORT:-8001}",
+    "deploy": "bun run build && wrangler deploy",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "hono": "^4.8.5",
+    "lucide-react": "^0.525.0",
+    "pino": "^9.11.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "6.30.0",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.9.4",
+    "@cloudflare/workers-types": "^4.20250807.0",
+    "@types/node": "^22.15.3",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "typescript": "5.8",
+    "vite": "^6.3.1"
+  }
+}
+`;
+
+const SCRATCH_WRANGLER_JSONC = `{
+  "name": "scratch-project",
+  "main": "worker/index.ts",
+  "compatibility_date": "2025-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "dist",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true,
+    "binding": "ASSETS"
+  },
+  "observability": {
+    "enabled": true
+  }
+}
+`;
+
 const SCRATCH_TEMPLATE_INSTRUCTIONS = `
 To build a valid, previewable and deployable project, it is essential to follow few important rules:
 
-1. The package.json **MUST** be of the following form: 
-\`\`\`
-...
-	"scripts": {
-		"dev": "vite --host 0.0.0.0 --port \${PORT:-8001}",
-		"build": "vite build",
-		"lint": "eslint --cache -f json --quiet .",
-		"preview": "bun run build && vite preview --host 0.0.0.0 --port \${PORT:-8001}",
-		"deploy": "bun run build && wrangler deploy",
-		"cf-typegen": "wrangler types"
-	}
-...
-\`\`\`
-
-Failure to have a compatible package.json would result in the app un-previewable and un-deployable.
+1. A baseline \`package.json\` is already provided with required scripts and core dependencies. You may modify it to add additional dependencies your code needs.
 
 2. The project **MUST** be a valid Cloudflare worker/durable object + Vite + bun project. 
 
-3. It must have a valid wrangler.jsonc and a vite.config.ts file.
+3. A \`wrangler.jsonc\` is already provided and **MUST NOT be modified**. It is preconfigured for the deployment environment.
 
-4. The vite config file MUST have the following minimal config:
-\`\`\`ts
-${VITE_CONFIG_MINIMAL}
-\`\`\`
+4. A \`vite.config.ts\` is already provided. **DO NOT modify it** unless absolutely necessary.
 `;
 
 /**
@@ -135,13 +175,17 @@ export function createScratchTemplateDetails(): TemplateDetails {
         name: 'scratch',
         description: { selection: 'from-scratch baseline', usage: `No template. Agent will scaffold as needed. **IT IS RECOMMENDED THAT YOU CHOOSE A VALID PRECONFIGURED TEMPLATE IF POSSIBLE** ${SCRATCH_TEMPLATE_INSTRUCTIONS}` },
         fileTree: { path: '/', type: 'directory', children: [] },
-        allFiles: {},
+        allFiles: {
+            'package.json': SCRATCH_PACKAGE_JSON,
+            'vite.config.ts': VITE_CONFIG_MINIMAL,
+            'wrangler.jsonc': SCRATCH_WRANGLER_JSONC,
+        },
         language: 'typescript',
         deps: {},
         projectType: 'general',
         frameworks: [],
         importantFiles: [],
-        dontTouchFiles: [],
+        dontTouchFiles: ['wrangler.jsonc'],
         redactedFiles: [],
         disabled: false,
     };


### PR DESCRIPTION
## Summary
This PR fixes preview URL issues by implementing two key improvements:
1. A sandbox readiness mechanism to prevent race conditions when fetching runtime errors
2. Pre-configured baseline files for scratch templates to ensure projects start in a valid, previewable state

## Changes
- **worker/agents/core/behaviors/base.ts**: Added sandbox readiness promise pattern
  - New `sandboxReadyPromise` and `resolveSandboxReady` for async synchronization
  - New `waitForSandboxReady()` method with configurable timeout (default 5s)
  - Guard in `fetchIssues()` to wait for sandbox before fetching runtime errors
  - Resolves sandbox promise when sandbox setup completes

- **worker/agents/utils/templates.ts**: Enhanced scratch template with baseline files
  - Added `SCRATCH_PACKAGE_JSON` with required scripts and dependencies
  - Added `SCRATCH_WRANGLER_JSONC` with Cloudflare Worker configuration
  - Updated `createScratchTemplateDetails()` to include baseline files
  - Added `wrangler.jsonc` to `dontTouchFiles` to prevent modification
  - Simplified template instructions to reference pre-provided files

## Motivation
Previously, scratch projects could fail to preview because:
1. Code could attempt to fetch runtime errors before the sandbox was fully initialized
2. Scratch templates lacked essential configuration files (package.json, wrangler.jsonc, vite.config.ts)

This PR ensures scratch projects start with a complete, valid configuration and prevents timing issues with sandbox initialization.

## Testing
- Create a new scratch project and verify preview works immediately
- Verify that fetching issues waits appropriately for sandbox initialization
- Confirm wrangler.jsonc cannot be modified by the agent

## Related Issues
None identified.

---
*Note: Remerge due to parent branch already being merged*