### PR TITLE
feat: reduce limits

### DIFF
--- a/worker/services/rate-limit/config.ts
+++ b/worker/services/rate-limit/config.ts
@@ -72,16 +72,16 @@ export const DEFAULT_RATE_LIMIT_SETTINGS: RateLimitSettings = {
 	appCreation: {
 		enabled: true,
 		store: RateLimitStore.DURABLE_OBJECT,
-		limit: 10,
-        dailyLimit: 10,
-		period: 4 * 60 * 60, // 4 hour
+		limit: 3,
+		dailyLimit: 3,
+		period: 24 * 60 * 60, // 24 hours
 	},
 	llmCalls: {
 		enabled: true,
 		store: RateLimitStore.DURABLE_OBJECT,
-		limit: 500,
-		period: 2 * 60 * 60, // 2 hour
-        dailyLimit: 1700,
+		limit: 250,
+		period: 24 * 60 * 60, // 24 hours
+		dailyLimit: 250,
 		excludeBYOKUsers: true,
 	},
 };


### PR DESCRIPTION
## Summary
Reduces rate limits for app creation and LLM calls to more restrictive values with 24-hour periods.

## Changes
- **App Creation**: Reduced from 10 apps/4 hours to 3 apps/24 hours
- **LLM Calls**: Reduced from 500 calls/2 hours (1700 daily) to 250 calls/24 hours
- Standardized both rate limit periods to 24 hours

## Motivation
Tighten rate limiting to reduce resource usage and prevent abuse.

## Testing
- Verify rate limits are applied correctly for new app creation
- Verify LLM call limits work as expected
- Confirm BYOK users are still excluded from LLM rate limits

## Breaking Changes
Users will experience significantly lower rate limits:
| Limit Type | Before | After |
|------------|--------|-------|
| App Creation | 10/4h | 3/24h |
| LLM Calls (period) | 500/2h | 250/24h |
| LLM Calls (daily) | 1700 | 250 |