### PR TITLE
Nightly -> Main

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -36,10 +36,10 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_AI_GATEWAY_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }}
         with:
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-5'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
           forks: 'false'
           permissions: write
-          opencode_version: '1.2.27'
+          opencode_version: 'latest'
           # The auto-reviewer must never push to PR branches. NO_PUSH
           # enforces contents: read at the token level so it holds even
           # if the model ignores prompt instructions.
@@ -58,3 +58,5 @@ jobs:
             Flag only medium and high priority issues — skip formatting the linter
             handles, pre-existing issues, and hypothetical edge cases.
             If the PR is clean, respond with only "LGTM!" and nothing else.
+
+            Leave the final review body empty — OpenCode posts the summary for you.

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -36,7 +36,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_AI_GATEWAY_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }}
         with:
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-5'
           forks: 'false'
           permissions: write
           opencode_version: '1.2.27'
@@ -58,5 +58,3 @@ jobs:
             Flag only medium and high priority issues — skip formatting the linter
             handles, pre-existing issues, and hypothetical edge cases.
             If the PR is clean, respond with only "LGTM!" and nothing else.
-
-            Leave the final review body empty — OpenCode posts the summary for you.

--- a/worker/services/rate-limit/config.ts
+++ b/worker/services/rate-limit/config.ts
@@ -72,16 +72,16 @@ export const DEFAULT_RATE_LIMIT_SETTINGS: RateLimitSettings = {
 	appCreation: {
 		enabled: true,
 		store: RateLimitStore.DURABLE_OBJECT,
-		limit: 10,
-        dailyLimit: 10,
-		period: 4 * 60 * 60, // 4 hour
+		limit: 3,
+		dailyLimit: 3,
+		period: 24 * 60 * 60, // 24 hours
 	},
 	llmCalls: {
 		enabled: true,
 		store: RateLimitStore.DURABLE_OBJECT,
-		limit: 500,
-		period: 2 * 60 * 60, // 2 hour
-        dailyLimit: 1700,
+		limit: 250,
+		period: 24 * 60 * 60, // 24 hours
+		dailyLimit: 250,
 		excludeBYOKUsers: true,
 	},
 };


### PR DESCRIPTION
## Summary
Reduces rate limits for app creation and LLM calls, and updates the AI PR review workflow to use the latest opencode version.

## Changes
- **Rate Limits**: Significantly reduced limits for both app creation and LLM calls
  - App creation: 10 per 4h → 3 per 24h
  - LLM calls: 500 per 2h + 1700 daily → 250 per 24h
- **AI Review Workflow**: Changed opencode_version from `1.2.27` to `latest`

## Motivation
Tightening rate limits to control resource usage and costs. The opencode version update ensures the AI PR review workflow uses the latest available version.

## Testing
- Verify rate limiting behavior in staging environment
- Confirm AI PR review workflow runs successfully with the updated opencode version

## Breaking Changes
Users will experience stricter rate limits:
- App creation limited to 3 per day (was 10 per 4 hours)
- LLM calls limited to 250 per day (was 1700 per day)