### PR TITLE
fix(deploy): resolve worker bundle path from @cloudflare/vite-plugin dist layout

### DIFF
--- a/worker/services/sandbox/resolveBuildArtifacts.test.ts
+++ b/worker/services/sandbox/resolveBuildArtifacts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBuildArtifacts } from './sandboxSdkClient';
+
+type Session = Parameters<typeof resolveBuildArtifacts>[0];
+
+function fakeSession(files: Record<string, string>): Session {
+	return {
+		async exec(cmd) {
+			const m = cmd.match(/^find (\S+) -maxdepth 2 -name wrangler\.json/);
+			if (!m) return { exitCode: 1, stdout: '', stderr: 'unexpected exec' };
+			const root = m[1];
+			const matches = Object.keys(files).filter(p => p.startsWith(`${root}/`) && p.endsWith('/wrangler.json'));
+			return { exitCode: 0, stdout: matches.join('\n'), stderr: '' };
+		},
+		async readFile(path) {
+			return path in files ? { success: true, content: files[path] } : { success: false };
+		},
+	};
+}
+
+describe('resolveBuildArtifacts', () => {
+	it('reads the plugin-emitted wrangler.json and resolves ../client to a dist sibling', async () => {
+		// Verbatim shape from `bun run build` of a typical vite-plugin generated app.
+		const session = fakeSession({
+			'/workspace/i-abc/dist/lumina_hello_world/wrangler.json': JSON.stringify({
+				name: 'lumina-hello-world',
+				main: 'index.js',
+				assets: { directory: '../client' },
+			}),
+		});
+
+		expect(await resolveBuildArtifacts(session, 'i-abc', 'lumina-hello-world')).toEqual({
+			workerPath: '/workspace/i-abc/dist/lumina_hello_world/index.js',
+			assetsPath: '/workspace/i-abc/dist/client',
+		});
+	});
+
+	it('picks the env dir matching workerName when multiple are emitted', async () => {
+		const session = fakeSession({
+			'/workspace/i-abc/dist/api/wrangler.json': JSON.stringify({ name: 'api', main: 'index.js' }),
+			'/workspace/i-abc/dist/web/wrangler.json': JSON.stringify({
+				name: 'web', main: 'index.js', assets: { directory: '../client' },
+			}),
+		});
+
+		expect(await resolveBuildArtifacts(session, 'i-abc', 'web')).toEqual({
+			workerPath: '/workspace/i-abc/dist/web/index.js',
+			assetsPath: '/workspace/i-abc/dist/client',
+		});
+	});
+
+	it('falls back to legacy dist/index.js paths when no nested wrangler.json exists', async () => {
+		// Byte-for-byte the strings the deploy code used before the nested layout.
+		expect(await resolveBuildArtifacts(fakeSession({}), 'i-abc', 'anything')).toEqual({
+			workerPath: '/workspace/i-abc/dist/index.js',
+			assetsPath: 'i-abc/dist/client',
+		});
+	});
+});

--- a/worker/services/sandbox/sandboxSdkClient.ts
+++ b/worker/services/sandbox/sandboxSdkClient.ts
@@ -30,6 +30,7 @@ import { createObjectLogger } from '../../logger';
 import { env } from 'cloudflare:workers'
 import { BaseSandboxService } from './BaseSandboxService';
 
+import { parse } from 'jsonc-parser';
 import { 
     buildDeploymentConfig, 
     parseWranglerConfig, 
@@ -66,6 +67,48 @@ interface InstanceMetadata {
 type SandboxType = Sandbox;
 
 type ExecutionSession = Awaited<ReturnType<Sandbox['createSession']>>;
+
+type WranglerJson = { name?: string; main?: string; assets?: { directory?: string } };
+
+/**
+ * `@cloudflare/vite-plugin` >= 1.0 emits a rewritten wrangler.json at
+ * `dist/<env>/wrangler.json` with the real `main` and `assets.directory`. We
+ * read it rather than reproducing the plugin's name-sanitization. Legacy
+ * templates that wrote `dist/index.js` directly fall through.
+ */
+export async function resolveBuildArtifacts(
+    session: { exec(c: string): Promise<ExecResult>; readFile(p: string): Promise<{ success: boolean; content?: string }> },
+    instanceId: string,
+    workerName: string,
+): Promise<{ workerPath: string; assetsPath: string | null }> {
+    const distDir = `/workspace/${instanceId}/dist`;
+    const find = await session.exec(`find ${distDir} -maxdepth 2 -name wrangler.json -type f 2>/dev/null`);
+    const candidates = find.stdout.split('\n').map(p => p.trim()).filter(Boolean);
+
+    let fallback: { dir: string; cfg: WranglerJson } | undefined;
+    for (const path of candidates) {
+        const file = await session.readFile(path);
+        if (!file.success || !file.content) continue;
+        const cfg = parse(file.content) as WranglerJson | undefined;
+        if (!cfg || typeof cfg.main !== 'string') continue;
+        const dir = path.slice(0, path.lastIndexOf('/'));
+        if (cfg.name === workerName) return resolveFromCfg(dir, cfg);
+        fallback ??= { dir, cfg };
+    }
+    if (fallback) return resolveFromCfg(fallback.dir, fallback.cfg);
+
+    return { workerPath: `${distDir}/index.js`, assetsPath: `${instanceId}/dist/client` };
+}
+
+function resolveFromCfg(dir: string, cfg: WranglerJson): { workerPath: string; assetsPath: string | null } {
+    const assetsDir = cfg.assets?.directory;
+    return {
+        workerPath: `${dir}/${cfg.main}`,
+        assetsPath: assetsDir === undefined ? null
+            : assetsDir.startsWith('../') ? `${dir.slice(0, dir.lastIndexOf('/'))}/${assetsDir.slice(3)}`
+            : `${dir}/${assetsDir}`,
+    };
+}
 
 /**
  * Streaming event for enhanced command execution
@@ -1783,11 +1826,12 @@ export class SandboxSdkClient extends BaseSandboxService {
             this.logger.info('Worker compatibility', { compatibilityDate: config.compatibility_date });
             
             // Step 3: Read worker script from dist
-            this.logger.info('Reading worker script');
             const session = await this.getInstanceSession(instanceId);
-            const workerFile = await session.readFile(`/workspace/${instanceId}/dist/index.js`);
+            const { workerPath, assetsPath } = await resolveBuildArtifacts(session, instanceId, config.name);
+            this.logger.info('Reading worker script', { workerPath, assetsPath });
+            const workerFile = await session.readFile(workerPath);
             if (!workerFile.success) {
-                throw new Error(`Worker script not found at /${instanceId}/dist/index.js. Please build the project first.`);
+                throw new Error(`Worker script not found at ${workerPath}. Please build the project first.`);
             }
             
             const workerContent = workerFile.content;
@@ -1840,14 +1884,13 @@ export class SandboxSdkClient extends BaseSandboxService {
             }
             
             // Step 4: Check for static assets and process them
-            const assetsPath = `${instanceId}/dist/client`;
             let assetsManifest: Record<string, { hash: string; size: number }> | undefined;
             let fileContents: Map<string, Buffer> | undefined;
             
-            const assetDirResult = await this.safeSandboxExec(`test -d ${assetsPath} && echo "exists" || echo "missing"`);
-            const hasAssets = assetDirResult.exitCode === 0 && assetDirResult.stdout.trim() === "exists";
-            
-            if (hasAssets) {
+            const assetDirCheck = assetsPath
+                ? await this.safeSandboxExec(`test -d ${assetsPath} && echo "exists" || echo "missing"`)
+                : null;
+            if (assetsPath && assetDirCheck?.exitCode === 0 && assetDirCheck.stdout.trim() === "exists") {
                 this.logger.info('Processing static assets', { assetsPath });
                 const assetProcessResult = await this.processAssetsInSandbox(instanceId, assetsPath);
                 assetsManifest = assetProcessResult.assetsManifest;


### PR DESCRIPTION
### Summary
The **Deploy to Cloudflare** button on generated apps fails with:

```text
FileNotFoundError: File not found: /workspace/<instanceId>/dist/index.js
```

### Root cause
`worker/services/sandbox/sandboxSdkClient.ts` reads a hardcoded `/workspace/<id>/dist/index.js`, but `@cloudflare/vite-plugin` emits the worker to `dist/<sanitized-name>/index.js` and writes a rewritten `wrangler.json` alongside it. The same file already reads static assets from the modern `dist/client/` layout, so the worker-read path was the inconsistent piece.

The hardcoded `dist/index.js` has been present since the initial OSS release. The user-facing regression surfaced when the R2-hosted templates switched to use `@cloudflare/vite-plugin`, shifting builds from the flat `dist/index.js` layout to the plugin's nested `dist/<env>/index.js` layout.

Verified against a real generated app (`lumina-the-beautiful-hello-world`):

- `dist/lumina_hello_world_zqneqpyztwbhid_y98ifi/index.js` exists
- `dist/lumina_hello_world_zqneqpyztwbhid_y98ifi/wrangler.json` exists with `main: "index.js"`, `assets.directory: "../client"`
- `dist/client/` exists
- `dist/index.js`, the path the code tries to read, does not exist

### Fix
Resolve both paths from the plugin's own `dist/<env>/wrangler.json` as the canonical source of truth, falling back to the legacy `dist/index.js` + `dist/client` layout for older templates byte-for-byte.

The fix is strictly local to `deployToCloudflareWorkers` in `worker/services/sandbox/sandboxSdkClient.ts`. `parseWranglerConfig`, `buildDeploymentConfig`, `WranglerConfig` type, `deployer.ts`, `deploy.ts`, `cloudflare-api.ts`, `templates.ts`, and the `bunx wrangler build` step are untouched.

### Tests
New unit tests in `worker/services/sandbox/resolveBuildArtifacts.test.ts` cover:

1. Modern `@cloudflare/vite-plugin` layout with `../client` assets resolving to sibling `dist/client`.
2. Multiple env dirs such as `api` and `web`, picking the one matching `config.name`.
3. No nested `wrangler.json`, preserving byte-identical legacy strings.

### Verification
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run test -- worker/services/sandbox/resolveBuildArtifacts.test.ts` passed
- `npm run test` passed: 216 passed / 1 skipped across 10 test files