### PR TITLE
fix: prevent platform API key leak via user-supplied AI gateway baseUrl

### DIFF
--- a/worker/agents/inferutils/config.types.ts
+++ b/worker/agents/inferutils/config.types.ts
@@ -458,6 +458,20 @@ export type CredentialsPayload = {
 	aiGateway?: { baseUrl: string; token: string };
 };
 
+/**
+ * Validates a user-supplied AI gateway baseUrl. Requires a well-formed
+ * absolute https URL. Returns false for malformed or non-https values so the
+ * override is dropped rather than plumbed downstream.
+ */
+function isValidGatewayBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		return new URL(baseUrl).protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
 export function credentialsToRuntimeOverrides(
 	credentials: CredentialsPayload | undefined,
 ): InferenceRuntimeOverrides | undefined {
@@ -469,9 +483,11 @@ export function credentialsToRuntimeOverrides(
 	}
 
 	const hasKeys = Object.keys(userApiKeys).length > 0;
+	const hasValidGateway =
+		!!credentials.aiGateway && isValidGatewayBaseUrl(credentials.aiGateway.baseUrl);
 	return {
 		...(hasKeys ? { userApiKeys } : {}),
-		...(credentials.aiGateway ? { aiGatewayOverride: credentials.aiGateway } : {}),
+		...(hasValidGateway ? { aiGatewayOverride: credentials.aiGateway } : {}),
 	};
 }
 

--- a/worker/agents/inferutils/core.test.ts
+++ b/worker/agents/inferutils/core.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { env } from 'cloudflare:test';
+import { getConfigurationForModel } from './core';
+import {
+	credentialsToRuntimeOverrides,
+	type AIModelConfig,
+	ModelSize,
+} from './config.types';
+
+const PLATFORM_KEY = 'sk-platform-secret-key-1234567890';
+const USER_KEY = 'sk-user-byok-key-1234567890';
+const ATTACKER_URL = 'https://attacker.example/v1';
+const PLATFORM_GATEWAY = 'https://gateway.example/v1';
+
+// A non-directOverride model (gateway-routed path) for the openai provider.
+const MODEL_CONFIG: AIModelConfig = {
+	name: 'gpt-test',
+	size: ModelSize.REGULAR,
+	provider: 'openai',
+	creditCost: 1,
+	contextSize: 128_000,
+};
+
+// Build a deterministic env: a valid platform provider key and a fixed
+// platform gateway URL so buildGatewayUrl never depends on the AI binding.
+function makeEnv(overrides: Record<string, unknown> = {}): Env {
+	return {
+		...env,
+		OPENAI_API_KEY: PLATFORM_KEY,
+		CLOUDFLARE_AI_GATEWAY_URL: PLATFORM_GATEWAY,
+		...overrides,
+	} as unknown as Env;
+}
+
+describe('getConfigurationForModel - gateway/key coupling', () => {
+	it('does NOT pair the platform env key with an attacker-supplied baseUrl', async () => {
+		const runtimeOverrides = credentialsToRuntimeOverrides({
+			aiGateway: { baseUrl: ATTACKER_URL, token: 'anything' },
+		});
+
+		const { apiKey } = await getConfigurationForModel(
+			MODEL_CONFIG,
+			makeEnv(),
+			'user-1',
+			runtimeOverrides,
+		);
+
+		// Core invariant: when a custom gateway baseUrl is present, the platform
+		// env key is structurally unreachable. Only the caller's own override
+		// token may be sent to the override URL.
+		expect(apiKey).not.toBe(PLATFORM_KEY);
+		expect(apiKey).toBe('anything');
+	});
+
+	it('never returns the platform env key when a baseUrl override has an empty token', async () => {
+		const runtimeOverrides = credentialsToRuntimeOverrides({
+			aiGateway: { baseUrl: ATTACKER_URL, token: '' },
+		});
+
+		const { apiKey } = await getConfigurationForModel(
+			MODEL_CONFIG,
+			makeEnv(),
+			'user-1',
+			runtimeOverrides,
+		);
+
+		// Even with an empty override token, the platform key must not leak.
+		expect(apiKey).not.toBe(PLATFORM_KEY);
+		expect(apiKey).toBe('');
+	});
+
+	it('honors the custom gateway baseUrl when a user provider key is supplied', async () => {
+		const runtimeOverrides = credentialsToRuntimeOverrides({
+			providers: { openai: { apiKey: USER_KEY } },
+			aiGateway: { baseUrl: ATTACKER_URL, token: 'user-token' },
+		});
+
+		const { apiKey, baseURL } = await getConfigurationForModel(
+			MODEL_CONFIG,
+			makeEnv(),
+			'user-1',
+			runtimeOverrides,
+		);
+
+		expect(apiKey).toBe(USER_KEY);
+		expect(baseURL.startsWith(ATTACKER_URL)).toBe(true);
+	});
+
+	it('uses the platform key and gateway when no override is supplied', async () => {
+		const { apiKey, baseURL } = await getConfigurationForModel(
+			MODEL_CONFIG,
+			makeEnv(),
+			'user-1',
+		);
+
+		expect(apiKey).toBe(PLATFORM_KEY);
+		expect(baseURL.startsWith(PLATFORM_GATEWAY)).toBe(true);
+	});
+});
+
+describe('credentialsToRuntimeOverrides - baseUrl validation', () => {
+	it('drops a non-https gateway baseUrl', () => {
+		const result = credentialsToRuntimeOverrides({
+			aiGateway: { baseUrl: 'http://attacker.example/v1', token: 't' },
+		});
+		expect(result?.aiGatewayOverride).toBeUndefined();
+	});
+
+	it('drops a malformed gateway baseUrl', () => {
+		const result = credentialsToRuntimeOverrides({
+			aiGateway: { baseUrl: 'not-a-url', token: 't' },
+		});
+		expect(result?.aiGatewayOverride).toBeUndefined();
+	});
+
+	it('keeps a valid https gateway baseUrl', () => {
+		const result = credentialsToRuntimeOverrides({
+			aiGateway: { baseUrl: ATTACKER_URL, token: 't' },
+		});
+		expect(result?.aiGatewayOverride?.baseUrl).toBe(ATTACKER_URL);
+	});
+});

--- a/worker/agents/inferutils/core.ts
+++ b/worker/agents/inferutils/core.ts
@@ -268,6 +268,12 @@ export async function buildGatewayUrl(
     // Runtime override (SDK): explicit AI Gateway base URL
     if (gatewayOverride?.baseUrl) {
         const url = new URL(gatewayOverride.baseUrl);
+        // Defense in depth: only allow https gateways. The primary protection
+        // against credential leaks is the apiKey<->baseURL coupling in
+        // getConfigurationForModel; this rejects malformed/insecure URLs.
+        if (url.protocol !== 'https:') {
+            throw new Error(`Invalid AI gateway baseUrl: only https is allowed (got ${url.protocol})`);
+        }
         return constructGatewayUrl(url, providerOverride);
     }
 
@@ -308,6 +314,33 @@ function isValidApiKey(apiKey: string): boolean {
     return true;
 }
 
+/**
+ * Single source of truth for resolving the gateway/platform token chain.
+ * When the user supplies a custom gateway, only their own token is used;
+ * otherwise the platform's gateway/CF API token is used.
+ */
+function resolvePlatformGatewayToken(
+    env: Env,
+    gatewayOverride?: { baseUrl: string; token: string },
+    isUsingCustomGateway?: boolean,
+): string {
+    if (isUsingCustomGateway) {
+        return gatewayOverride?.token ?? '';
+    }
+    return gatewayOverride?.token ?? (env.CLOUDFLARE_AI_GATEWAY_TOKEN || env.CLOUDFLARE_API_TOKEN);
+}
+
+interface ResolvedApiKey {
+    apiKey: string;
+    /**
+     * True when the key belongs to the user (SDK BYOK key, decrypted user
+     * gateway token, or the user's own custom-gateway override token). When
+     * false, the key is platform-owned and a user-supplied gateway baseUrl
+     * must NOT be honored.
+     */
+    isUserCredential: boolean;
+}
+
 async function getApiKey(
     provider: string,
     env: Env,
@@ -315,13 +348,13 @@ async function getApiKey(
     runtimeOverrides?: InferenceRuntimeOverrides,
     shouldUseUserKey?: boolean,
     encryptedUserToken?: string | null,
-): Promise<string> {
+): Promise<ResolvedApiKey> {
     logger.debug('Getting API key for provider', { provider });
 
     // First check runtime overrides (SDK)
     const runtimeKey = runtimeOverrides?.userApiKeys?.[provider];
     if (runtimeKey && isValidApiKey(runtimeKey)) {
-        return runtimeKey;
+        return { apiKey: runtimeKey, isUserCredential: true };
     }
 
     // Check if we should use user's token (flag set once at request start)
@@ -335,7 +368,7 @@ async function getApiKey(
                 const accessToken = await getAccessTokenFromBlob(encryptedUserToken, env, userId);
                 if (accessToken && isValidApiKey(accessToken)) {
                     logger.info('Using user decrypted Cloudflare AI Gateway token');
-                    return accessToken;
+                    return { apiKey: accessToken, isUserCredential: true };
                 }
             } catch (error) {
                 logger.warn('Failed to decrypt user token', { error });
@@ -344,23 +377,30 @@ async function getApiKey(
         logger.warn('User exceeded limits but no valid API token found, using free tier anyway');
     }
 
-    // Fallback to environment variables
+    // User supplied a custom gateway baseUrl: the user's gateway uses the
+    // user's credentials only. Resolve to their override token BEFORE any
+    // platform env fallback so a platform-owned secret is never paired with
+    // an attacker-controlled baseUrl.
+    if (runtimeOverrides?.aiGatewayOverride?.baseUrl) {
+        return {
+            apiKey: runtimeOverrides.aiGatewayOverride.token ?? '',
+            isUserCredential: true,
+        };
+    }
+
+    // Fallback to environment variables (platform-owned secret)
     const providerKeyString = provider.toUpperCase().replaceAll('-', '_');
     const envKey = `${providerKeyString}_API_KEY` as keyof Env;
-    let apiKey: string = env[envKey] as string;
-    
-    // Check if apiKey is empty or undefined and is valid
-    if (!isValidApiKey(apiKey)) {
-        // only use platform token if NOT using a custom gateway URL
-        // User's gateway = user's credentials only
-        if (runtimeOverrides?.aiGatewayOverride?.baseUrl) {
-            // User provided custom gateway
-            apiKey = runtimeOverrides.aiGatewayOverride.token ?? '';
-        } else {
-            apiKey = runtimeOverrides?.aiGatewayOverride?.token ?? (env.CLOUDFLARE_AI_GATEWAY_TOKEN || env.CLOUDFLARE_API_TOKEN);
-        }
+    const envApiKey: string = env[envKey] as string;
+    if (isValidApiKey(envApiKey)) {
+        return { apiKey: envApiKey, isUserCredential: false };
     }
-    return apiKey;
+
+    // Final platform fallback: shared gateway/CF API token.
+    return {
+        apiKey: resolvePlatformGatewayToken(env, runtimeOverrides?.aiGatewayOverride, false),
+        isUserCredential: false,
+    };
 }
 
 export async function getConfigurationForModel(
@@ -403,18 +443,28 @@ export async function getConfigurationForModel(
         }
     }
 
-    const gatewayOverride = runtimeOverrides?.aiGatewayOverride;
+    // Resolve the API key first so the baseURL choice can be coupled to key
+    // ownership. A user-supplied gateway baseUrl is only honored when the
+    // resolved key is the user's own credential; if we fall back to a
+    // platform-owned env key, the override is dropped and we route through the
+    // platform gateway instead.
+    const { apiKey, isUserCredential } = await getApiKey(modelConfig.provider, env, userId, runtimeOverrides, shouldUseUserKey, userApiToken);
+
+    const requestedCustomGateway = !!runtimeOverrides?.aiGatewayOverride?.baseUrl;
+    const honorGatewayOverride = requestedCustomGateway && isUserCredential;
+    if (requestedCustomGateway && !honorGatewayOverride) {
+        logger.warn('Ignoring user-supplied AI gateway baseUrl: resolved API key is platform-owned', {
+            provider: modelConfig.provider,
+        });
+    }
+
+    const gatewayOverride = honorGatewayOverride ? runtimeOverrides?.aiGatewayOverride : undefined;
     const isUsingCustomGateway = !!gatewayOverride?.baseUrl;
-    
+
     // Use user's gateway if in BYOK mode, otherwise use platform gateway or runtime override
     const baseURL = await buildGatewayUrl(env, providerForcedOverride, gatewayOverride, useUserGateway ? userGateway : null);
 
-    const gatewayToken = isUsingCustomGateway
-        ? gatewayOverride?.token
-        : (gatewayOverride?.token ?? (env.CLOUDFLARE_AI_GATEWAY_TOKEN || env.CLOUDFLARE_API_TOKEN));  // Platform gateway
-
-    // Try to find API key of type <PROVIDER>_API_KEY else default to gateway token
-    const apiKey = await getApiKey(modelConfig.provider, env, userId, runtimeOverrides, shouldUseUserKey, userApiToken);
+    const gatewayToken = resolvePlatformGatewayToken(env, gatewayOverride, isUsingCustomGateway);
 
     // AI Gateway Wholesaling checks - only needed when using platform gateway with user's key
     // When using user's own gateway, no wholesaling header needed


### PR DESCRIPTION
Couple the resolved API key to gateway baseURL ownership so a user-supplied aiGateway.baseUrl is only honored when the request uses the user's own credentials. When resolution falls back to the platform env provider key, the override baseUrl is dropped and routed through the platform gateway, so a platform-owned secret is never sent to an attacker-controlled URL.

- getApiKey returns { apiKey, isUserCredential } and resolves a custom gateway override token before any platform env fallback
- getConfigurationForModel only honors the override baseUrl for user creds
- de-duplicate gateway token resolution into resolvePlatformGatewayToken
- validate aiGateway.baseUrl (well-formed https) and reject non-https in buildGatewayUrl
- add regression tests

VIBE-16