### PR TITLE
fix(preview): token+cookie auth for space previews and Safari banner

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistrableDomain } from './utils';
+
+// Note: `isCrossSitePreview` and `isAppleWebKitBrowser` depend on `window`/
+// `navigator` and are exercised in the browser, not this workers-pool harness.
+// The registrable-domain heuristic they build on is pure and covered here.
+describe('getRegistrableDomain', () => {
+	it('returns the eTLD+1 for simple hosts', () => {
+		expect(getRegistrableDomain('app.example.com')).toBe('example.com');
+		expect(getRegistrableDomain('preview.example.com')).toBe('example.com');
+		expect(getRegistrableDomain('example.com')).toBe('example.com');
+	});
+
+	it('treats different registrable domains as distinct', () => {
+		expect(getRegistrableDomain('myapp.com')).not.toBe(
+			getRegistrableDomain('mypreview.dev'),
+		);
+	});
+
+	it('handles common multi-part public suffixes', () => {
+		expect(getRegistrableDomain('app.example.co.uk')).toBe('example.co.uk');
+		expect(getRegistrableDomain('preview.example.com.au')).toBe('example.com.au');
+	});
+
+	it('strips the port and trailing dot, and lowercases', () => {
+		expect(getRegistrableDomain('App.Example.com:8080')).toBe('example.com');
+		expect(getRegistrableDomain('example.com.')).toBe('example.com');
+	});
+
+	it('handles single-label and empty hosts', () => {
+		expect(getRegistrableDomain('localhost')).toBe('localhost');
+		expect(getRegistrableDomain('')).toBe('');
+	});
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,3 +16,79 @@ export function capitalizeFirstLetter(str: string) {
   }
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+/**
+ * Detect Apple/WebKit browsers subject to Intelligent Tracking Prevention
+ * (ITP), which blocks third-party cookies for an origin embedded in a
+ * cross-site iframe. This covers desktop Safari and every iOS/iPadOS browser
+ * (all use WebKit). Best-effort UA sniffing; used only to decide whether to
+ * show an advisory banner.
+ */
+export function isAppleWebKitBrowser(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  const isIOS = /iPhone|iPad|iPod/.test(ua);
+  // iPadOS 13+ reports as "Macintosh" but exposes touch points.
+  const isIPadOS =
+    /Macintosh/.test(ua) &&
+    typeof navigator.maxTouchPoints === 'number' &&
+    navigator.maxTouchPoints > 1;
+  if (isIOS || isIPadOS) return true;
+  const isDesktopSafari =
+    /Safari/.test(ua) && !/Chrome|Chromium|CriOS|FxiOS|Edg|Android|OPR/.test(ua);
+  return isDesktopSafari;
+}
+
+const MULTI_PART_SUFFIXES = [
+  'co.uk',
+  'org.uk',
+  'gov.uk',
+  'ac.uk',
+  'com.au',
+  'net.au',
+  'org.au',
+  'co.in',
+  'co.jp',
+  'co.nz',
+  'co.za',
+  'com.br',
+];
+
+/**
+ * Best-effort registrable domain (eTLD+1) for a host. Strips the port and
+ * returns the last two labels, accounting for a small set of common
+ * multi-part public suffixes. Heuristic only (no full Public Suffix List);
+ * used to decide whether a preview iframe is cross-site for an advisory
+ * banner, never for a security decision.
+ */
+export function getRegistrableDomain(host: string): string {
+  if (!host) return '';
+  const bare = host.split(':')[0].toLowerCase().replace(/\.$/, '');
+  const labels = bare.split('.').filter(Boolean);
+  if (labels.length <= 2) return labels.join('.');
+  const lastTwo = labels.slice(-2).join('.');
+  if (MULTI_PART_SUFFIXES.includes(lastTwo)) {
+    return labels.slice(-3).join('.');
+  }
+  return lastTwo;
+}
+
+/**
+ * True when the preview URL is served from a different registrable domain than
+ * the current dashboard page (the case where Safari blocks the cross-site
+ * preview cookie). Returns false for same-origin, same-base-domain subdomains,
+ * or unparseable input.
+ */
+export function isCrossSitePreview(previewUrl: string): boolean {
+  if (!previewUrl || typeof window === 'undefined') return false;
+  try {
+    const previewHost = new URL(previewUrl).host;
+    const appHost = window.location.host;
+    const previewDomain = getRegistrableDomain(previewHost);
+    const appDomain = getRegistrableDomain(appHost);
+    if (!previewDomain || !appDomain) return false;
+    return previewDomain !== appDomain;
+  } catch {
+    return false;
+  }
+}

--- a/src/routes/chat/components/main-content-panel.tsx
+++ b/src/routes/chat/components/main-content-panel.tsx
@@ -6,6 +6,7 @@ import { RefreshCw } from 'lucide-react';
 import { Blueprint } from './blueprint';
 import { FileExplorer } from './file-explorer';
 import { PreviewIframe } from './preview-iframe';
+import { PreviewCompatBanner } from './preview-compat-banner';
 import { MarkdownDocsPreview } from './markdown-docs-preview';
 import { ViewContainer } from './view-container';
 import { ViewHeader } from './view-header';
@@ -282,7 +283,10 @@ export function MainContentPanel(props: MainContentPanelProps) {
 					</button>
 				)}
 			</div>,
-			previewContent,
+			<div className="flex flex-1 min-h-0 flex-col">
+				<PreviewCompatBanner previewUrl={previewUrl} />
+				<div className="relative flex flex-1 min-h-0 flex-col">{previewContent}</div>
+			</div>,
 			headerActions
 		);
 	};

--- a/src/routes/chat/components/preview-compat-banner.tsx
+++ b/src/routes/chat/components/preview-compat-banner.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from 'react';
+import { ExternalLink, TriangleAlert, X } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { isAppleWebKitBrowser, isCrossSitePreview } from '@/lib/utils';
+
+const DISMISS_KEY = 'preview-compat-dismissed';
+
+function readDismissed(): boolean {
+	try {
+		return sessionStorage.getItem(DISMISS_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+
+interface PreviewCompatBannerProps {
+	previewUrl: string;
+}
+
+/**
+ * Advisory banner shown above the preview when the viewer is on an Apple/WebKit
+ * browser AND the preview runs on a different registrable domain than the
+ * dashboard. In that case Safari blocks the cross-site preview cookie, so the
+ * embedded iframe's dynamic requests can fail. Opening the preview in a new tab
+ * loads it first-party, where it works fully.
+ */
+export function PreviewCompatBanner({ previewUrl }: PreviewCompatBannerProps) {
+	const [dismissed, setDismissed] = useState(readDismissed);
+
+	const show = useMemo(
+		() => isAppleWebKitBrowser() && isCrossSitePreview(previewUrl),
+		[previewUrl],
+	);
+
+	if (!show || dismissed) {
+		return null;
+	}
+
+	const dismiss = () => {
+		try {
+			sessionStorage.setItem(DISMISS_KEY, '1');
+		} catch {
+			// Ignore storage failures; banner just won't persist its dismissal.
+		}
+		setDismissed(true);
+	};
+
+	return (
+		<Alert className="rounded-none border-x-0 border-t-0 flex items-center gap-3">
+			<TriangleAlert className="text-amber-500" />
+			<AlertDescription className="flex-1">
+				Preview may not fully load in Safari due to preview being served from a
+				different domain.
+			</AlertDescription>
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={() =>
+					window.open(previewUrl, '_blank', 'noopener,noreferrer')
+				}
+			>
+				<ExternalLink />
+				Open in new tab
+			</Button>
+			<button
+				type="button"
+				aria-label="Dismiss"
+				onClick={dismiss}
+				className="p-1 rounded hover:bg-bg-2 transition-colors"
+			>
+				<X className="size-4 text-text-primary/60" />
+			</button>
+		</Alert>
+	);
+}

--- a/worker/agents/core/behaviors/think.ts
+++ b/worker/agents/core/behaviors/think.ts
@@ -345,11 +345,13 @@ export class ThinkCodingBehavior
 		const spaceName = this.getAgentId();
 		const branch = this.state.currentBranch || 'main';
 		const previewBaseUrl = `${await this.getPublicOrigin()}${buildSpacePreviewPath(spaceName, branch)}`;
-		if (isDev(this.env) || !isSeparatePreviewDomain(this.env)) {
-			return previewBaseUrl;
-		}
+		// Always append a signed, branch-scoped preview token. It bootstraps the
+		// path-scoped HttpOnly preview cookie on first load (so iframe sub-resources
+		// authenticate), and authenticates machine clients like the headless
+		// `get_browser_console_logs` browser, which carry no cookie.
 		const token = await signSpacePreviewToken(this.env, {
 			spaceName,
+			branch,
 			userId: this.state.metadata.userId,
 		});
 		return `${previewBaseUrl}?t=${encodeURIComponent(token)}`;

--- a/worker/api/handlers/space-preview.test.ts
+++ b/worker/api/handlers/space-preview.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { handleSpacePreview } from './space-preview';
+import {
+	buildPreviewCookie,
+	signSpacePreviewToken,
+	SPACE_PREVIEW_COOKIE_NAME,
+} from '../../utils/spacePreviewToken';
+
+const JWT_SECRET = 'test-secret-for-space-preview-token-validation-1234567890';
+
+type HandlerEnv = Parameters<typeof handleSpacePreview>[1];
+
+interface ForwardCapture {
+	lastRequest: Request | null;
+}
+
+function makeEnv(
+	overrides: Record<string, unknown> = {},
+	capture: ForwardCapture = { lastRequest: null },
+): HandlerEnv {
+	const stub = {
+		fetch: async (req: Request) => {
+			capture.lastRequest = req;
+			return new Response('<html><body><img src="/logo.png"></body></html>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		},
+	};
+	const namespace = {
+		idFromName: (name: string) => name,
+		get: () => stub,
+	};
+	return {
+		JWT_SECRET,
+		CUSTOM_DOMAIN: 'example.com',
+		CUSTOM_PREVIEW_DOMAIN: '',
+		SPACE_DO: namespace,
+		...overrides,
+	} as unknown as HandlerEnv;
+}
+
+function previewRequest(token?: string, cookie?: string): Request {
+	const url = token
+		? `https://example.com/space/space-a/preview/main/?t=${encodeURIComponent(token)}`
+		: 'https://example.com/space/space-a/preview/main/';
+	return new Request(url, cookie ? { headers: { Cookie: cookie } } : undefined);
+}
+
+describe('handleSpacePreview', () => {
+	it('forwards a valid ?t= token and sets the preview cookie (Lax, same-origin)', async () => {
+		const env = makeEnv();
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+		});
+
+		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
+		expect(res.status).toBe(200);
+		const setCookie = res.headers.get('Set-Cookie') ?? '';
+		expect(setCookie).toContain(`${SPACE_PREVIEW_COOKIE_NAME}=`);
+		expect(setCookie).toContain('HttpOnly');
+		expect(setCookie).toContain('Path=/space/space-a/preview/main');
+		expect(setCookie).toContain('SameSite=Lax');
+	});
+
+	it('forwards a request carrying a valid preview cookie (no ?t=)', async () => {
+		const env = makeEnv();
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+		});
+		const cookie = buildPreviewCookie({
+			token,
+			spaceName: 'space-a',
+			branch: 'main',
+			crossSite: false,
+			secure: true,
+		});
+
+		const res = await handleSpacePreview(
+			previewRequest(undefined, cookie),
+			env,
+			'space-a',
+			'main',
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it('returns 401 when neither token nor cookie is present', async () => {
+		const env = makeEnv();
+		const res = await handleSpacePreview(previewRequest(), env, 'space-a', 'main');
+		expect(res.status).toBe(401);
+	});
+
+	it('returns 401 for a token minted for a different branch', async () => {
+		const env = makeEnv();
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'feature',
+			userId: 'user-a',
+		});
+
+		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
+		expect(res.status).toBe(401);
+	});
+
+	it('on a separate preview domain, sets a partitioned cookie and strips ?t= before forwarding', async () => {
+		const capture: ForwardCapture = { lastRequest: null };
+		const env = makeEnv({ CUSTOM_PREVIEW_DOMAIN: 'preview.example.dev' }, capture);
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+		});
+
+		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
+		expect(res.status).toBe(200);
+		const setCookie = res.headers.get('Set-Cookie') ?? '';
+		expect(setCookie).toContain('SameSite=None');
+		expect(setCookie).toContain('Secure');
+		expect(setCookie).toContain('Partitioned');
+		// The generated app never sees the token.
+		expect(new URL(capture.lastRequest!.url).searchParams.get('t')).toBeNull();
+	});
+});

--- a/worker/api/handlers/space-preview.ts
+++ b/worker/api/handlers/space-preview.ts
@@ -1,17 +1,28 @@
-import { AppService } from '../../database';
-import { authMiddleware } from '../../middleware/auth/auth';
-import { verifySpacePreviewToken } from '../../utils/spacePreviewToken';
+import {
+	buildPreviewCookie,
+	readPreviewCookie,
+	verifySpacePreviewToken,
+} from '../../utils/spacePreviewToken';
+import { isSeparatePreviewDomain } from '../../utils/urls';
 
-const SPACE_PREVIEW_ROUTE_PATTERN = /^\/space\/([^/]+)\/preview\/[^/]+(?:\/.*)?$/;
+const SPACE_PREVIEW_ROUTE_PATTERN = /^\/space\/([^/]+)\/preview\/([^/]+)(?:\/.*)?$/;
 
 type SpaceNamespace = {
 	SPACE_DO?: DurableObjectNamespace;
 };
 
-export function matchSpacePreviewPath(pathname: string): string | null {
+export interface SpacePreviewParams {
+	spaceName: string;
+	branch: string;
+}
+
+export function matchSpacePreviewParams(pathname: string): SpacePreviewParams | null {
 	const match = pathname.match(SPACE_PREVIEW_ROUTE_PATTERN);
 	if (!match) return null;
-	return decodeURIComponent(match[1]);
+	return {
+		spaceName: decodeURIComponent(match[1]),
+		branch: decodeURIComponent(match[2]),
+	};
 }
 
 function getSpaceNamespace(env: Env): DurableObjectNamespace | null {
@@ -19,14 +30,22 @@ function getSpaceNamespace(env: Env): DurableObjectNamespace | null {
 	return spaceNamespace ?? null;
 }
 
-async function forwardToSpacePreview(request: Request, env: Env, spaceName: string): Promise<Response> {
+async function forwardToSpacePreview(
+	request: Request,
+	env: Env,
+	spaceName: string,
+): Promise<Response> {
 	const namespace = getSpaceNamespace(env);
 	if (!namespace) {
 		return new Response('Preview unavailable', { status: 404 });
 	}
+	// Strip `?t=` so the generated app never sees the token.
+	const forwardedUrl = new URL(request.url);
+	forwardedUrl.searchParams.delete('t');
+	const forwardedRequest = new Request(forwardedUrl.toString(), request);
 	const stub = namespace.get(namespace.idFromName(spaceName));
 	try {
-		return await stub.fetch(request);
+		return await stub.fetch(forwardedRequest);
 	} catch (e) {
 		// A SpaceDO failure (e.g. no deployment yet, or a build error in the
 		// generated app) must not escape as an unhandled exception — that
@@ -52,42 +71,54 @@ export function createPreviewAccessResponse(status: 401 | 403, title: string, me
 	);
 }
 
-export async function handleCookieAuthenticatedSpacePreview(
-	request: Request,
-	env: Env,
-	spaceName: string,
-): Promise<Response> {
-	const userSession = await authMiddleware(request, env);
-	if (!userSession) {
-		return createPreviewAccessResponse(401, 'Login required', 'You must be signed in as the app owner to view this preview.');
-	}
-
-	const appService = new AppService(env);
-	const ownershipResult = await appService.checkAppOwnership(spaceName, userSession.user.id);
-	if (!ownershipResult.isOwner) {
-		return createPreviewAccessResponse(403, 'Preview access denied', 'Only the owner of this app can view this preview.');
-	}
-
-	return forwardToSpacePreview(request, env, spaceName);
+function isWebSocketResponse(response: Response): boolean {
+	return response.status === 101 || response.headers.get('Upgrade')?.toLowerCase() === 'websocket';
 }
 
-export async function handleTokenAuthenticatedSpacePreview(
+/**
+ * Unified, token-only preview auth. A request is authorized if it carries a
+ * valid path/branch-scoped preview cookie, or a valid `?t=` token (which then
+ * bootstraps the cookie). No session cookie / DB ownership check (claims-only).
+ */
+export async function handleSpacePreview(
 	request: Request,
 	env: Env,
 	spaceName: string,
+	branch: string,
 ): Promise<Response> {
-	const token = new URL(request.url).searchParams.get('t') ?? '';
-	if (!token) {
-		return createPreviewAccessResponse(401, 'Access denied', 'This preview link is missing an access token.');
+	const url = new URL(request.url);
+	const crossSite = isSeparatePreviewDomain(env);
+	const secure = url.protocol === 'https:';
+
+	// 1. Existing preview cookie (covers iframe sub-resources / client fetches).
+	const cookieToken = readPreviewCookie(request);
+	if (cookieToken) {
+		const claims = await verifySpacePreviewToken(env, cookieToken, spaceName, branch);
+		if (claims) {
+			return forwardToSpacePreview(request, env, spaceName);
+		}
 	}
 
-	const claims = await verifySpacePreviewToken(env, token, spaceName);
-	if (!claims) {
+	// 2. `?t=` token: forward and bootstrap the cookie (serve-in-place).
+	const queryToken = url.searchParams.get('t') ?? '';
+	if (queryToken) {
+		const claims = await verifySpacePreviewToken(env, queryToken, spaceName, branch);
+		if (claims) {
+			const response = await forwardToSpacePreview(request, env, spaceName);
+			if (isWebSocketResponse(response)) {
+				return response;
+			}
+			const withCookie = new Response(response.body, response);
+			withCookie.headers.append(
+				'Set-Cookie',
+				buildPreviewCookie({ token: queryToken, spaceName, branch, crossSite, secure }),
+			);
+			return withCookie;
+		}
+	}
+
+	if (queryToken || cookieToken) {
 		return createPreviewAccessResponse(401, 'Access denied', 'This preview link is invalid or has expired.');
 	}
-
-	const forwardedUrl = new URL(request.url);
-	forwardedUrl.searchParams.delete('t');
-	const forwardedRequest = new Request(forwardedUrl.toString(), request);
-	return forwardToSpacePreview(forwardedRequest, env, spaceName);
+	return createPreviewAccessResponse(401, 'Access denied', 'This preview link is missing an access token.');
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -11,9 +11,8 @@ import { isDev } from './utils/envs';
 import { proxyToSandbox } from './services/sandbox/request-handler';
 import { handleGitProtocolRequest, isGitProtocolRequest } from './api/handlers/git-protocol';
 import {
-	handleCookieAuthenticatedSpacePreview,
-	handleTokenAuthenticatedSpacePreview,
-	matchSpacePreviewPath,
+	handleSpacePreview,
+	matchSpacePreviewParams,
 } from './api/handlers/space-preview';
 import { getAgentStub } from './agents';
 
@@ -69,6 +68,7 @@ function withPreviewCorsHeaders(env: Env, request: Request, response: Response):
     const headers = new Headers(response.headers);
     if (origin && (isDev(env) || allowedOrigins.includes(origin))) {
         headers.set('Access-Control-Allow-Origin', origin);
+        headers.set('Access-Control-Allow-Credentials', 'true');
         headers.append('Vary', 'Origin');
     }
     return new Response(response.body, {
@@ -216,22 +216,23 @@ const worker = {
 			(hostname.endsWith('.localhost') && hostname !== 'localhost');
 
 		if (separatePreviewDomain && hostname === previewDomain) {
-			const spaceName = matchSpacePreviewPath(pathname);
-			if (!spaceName) {
+			const params = matchSpacePreviewParams(pathname);
+			if (!params) {
 				return new Response('Not Found', { status: 404 });
 			}
-			const response = await handleTokenAuthenticatedSpacePreview(request, env, spaceName);
+			const response = await handleSpacePreview(request, env, params.spaceName, params.branch);
 			return withPreviewCorsHeaders(env, request, response);
 		}
 
 		// Route 1: Main Platform Request (e.g., build.cloudflare.dev or localhost)
 		if (isMainDomainRequest) {
-			const spaceName = matchSpacePreviewPath(pathname);
-			if (spaceName) {
+			const params = matchSpacePreviewParams(pathname);
+			if (params) {
 				if (separatePreviewDomain) {
 					return new Response('Not Found', { status: 404 });
 				}
-				return handleCookieAuthenticatedSpacePreview(request, env, spaceName);
+				const response = await handleSpacePreview(request, env, params.spaceName, params.branch);
+				return withPreviewCorsHeaders(env, request, response);
 			}
 
 			// Handle Git protocol endpoints directly

--- a/worker/utils/spacePreviewToken.test.ts
+++ b/worker/utils/spacePreviewToken.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { JWTUtils } from './jwtUtils';
-import { signSpacePreviewToken, verifySpacePreviewToken } from './spacePreviewToken';
+import {
+	buildPreviewCookie,
+	readPreviewCookie,
+	signSpacePreviewToken,
+	SPACE_PREVIEW_COOKIE_NAME,
+	verifySpacePreviewToken,
+} from './spacePreviewToken';
 
 const testEnv = {
 	JWT_SECRET: 'test-secret-for-space-preview-token-validation-1234567890',
@@ -10,12 +16,14 @@ describe('spacePreviewToken', () => {
 	it('verifies a valid signed token', async () => {
 		const token = await signSpacePreviewToken(testEnv, {
 			spaceName: 'space-a',
+			branch: 'main',
 			userId: 'user-a',
 		});
 
-		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a');
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'main');
 		expect(claims).toEqual({
 			spaceName: 'space-a',
+			branch: 'main',
 			userId: 'user-a',
 		});
 	});
@@ -23,10 +31,22 @@ describe('spacePreviewToken', () => {
 	it('rejects token for a different space', async () => {
 		const token = await signSpacePreviewToken(testEnv, {
 			spaceName: 'space-a',
+			branch: 'main',
 			userId: 'user-a',
 		});
 
-		const claims = await verifySpacePreviewToken(testEnv, token, 'space-b');
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-b', 'main');
+		expect(claims).toBeNull();
+	});
+
+	it('rejects token for a different branch', async () => {
+		const token = await signSpacePreviewToken(testEnv, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+		});
+
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'feature');
 		expect(claims).toBeNull();
 	});
 
@@ -35,13 +55,14 @@ describe('spacePreviewToken', () => {
 		const token = await jwt.signPayload(
 			{
 				spaceName: 'space-a',
+				branch: 'main',
 				userId: 'user-a',
 				purpose: 'not-space-preview',
 			},
 			60,
 		);
 
-		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a');
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'main');
 		expect(claims).toBeNull();
 	});
 
@@ -50,13 +71,70 @@ describe('spacePreviewToken', () => {
 		const token = await jwt.signPayload(
 			{
 				spaceName: 'space-a',
+				branch: 'main',
 				userId: 'user-a',
 				purpose: 'space_preview',
 			},
 			-1,
 		);
 
-		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a');
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'main');
 		expect(claims).toBeNull();
+	});
+});
+
+describe('preview cookie helpers', () => {
+	it('builds a Lax cookie for same-origin (no Secure over http)', () => {
+		const cookie = buildPreviewCookie({
+			token: 'abc',
+			spaceName: 'space-a',
+			branch: 'main',
+			crossSite: false,
+			secure: false,
+		});
+		expect(cookie).toContain(`${SPACE_PREVIEW_COOKIE_NAME}=abc`);
+		expect(cookie).toContain('Path=/space/space-a/preview/main');
+		expect(cookie).toContain('HttpOnly');
+		expect(cookie).toContain('SameSite=Lax');
+		expect(cookie).not.toContain('Secure');
+		expect(cookie).not.toContain('Partitioned');
+	});
+
+	it('builds a None;Secure;Partitioned cookie for a separate preview domain', () => {
+		const cookie = buildPreviewCookie({
+			token: 'abc',
+			spaceName: 'space-a',
+			branch: 'main',
+			crossSite: true,
+			secure: true,
+		});
+		expect(cookie).toContain('SameSite=None');
+		expect(cookie).toContain('Secure');
+		expect(cookie).toContain('Partitioned');
+	});
+
+	it('encodes the cookie path and avoids a trailing slash', () => {
+		const cookie = buildPreviewCookie({
+			token: 'abc',
+			spaceName: 'my space',
+			branch: 'feat/x',
+			crossSite: false,
+			secure: true,
+		});
+		expect(cookie).toContain('Path=/space/my%20space/preview/feat%2Fx');
+	});
+
+	it('reads the preview cookie value from the Cookie header', () => {
+		const request = new Request('https://example.com/', {
+			headers: { Cookie: `other=1; ${SPACE_PREVIEW_COOKIE_NAME}=tok123; foo=bar` },
+		});
+		expect(readPreviewCookie(request)).toBe('tok123');
+	});
+
+	it('returns null when no preview cookie is present', () => {
+		const request = new Request('https://example.com/', {
+			headers: { Cookie: 'other=1' },
+		});
+		expect(readPreviewCookie(request)).toBeNull();
 	});
 });

--- a/worker/utils/spacePreviewToken.ts
+++ b/worker/utils/spacePreviewToken.ts
@@ -1,10 +1,12 @@
 import { JWTUtils } from './jwtUtils';
 
 const PREVIEW_PURPOSE = 'space_preview';
-export const SPACE_PREVIEW_TOKEN_TTL_SECONDS = 24 * 60 * 60;
+export const SPACE_PREVIEW_TOKEN_TTL_SECONDS = 30 * 60;
+export const SPACE_PREVIEW_COOKIE_NAME = '__space_preview';
 
 export interface SpacePreviewClaims {
 	spaceName: string;
+	branch: string;
 	userId: string;
 }
 
@@ -20,16 +22,73 @@ export async function verifySpacePreviewToken(
 	env: { JWT_SECRET: string },
 	token: string,
 	expectedSpaceName: string,
+	expectedBranch: string,
 ): Promise<SpacePreviewClaims | null> {
 	const jwt = JWTUtils.getInstance(env);
 	const payload = await jwt.verifyPayload(token);
 	if (!payload) return null;
 	if (payload.purpose !== PREVIEW_PURPOSE) return null;
 	if (typeof payload.spaceName !== 'string' || payload.spaceName !== expectedSpaceName) return null;
+	if (typeof payload.branch !== 'string' || payload.branch !== expectedBranch) return null;
 	if (typeof payload.userId !== 'string' || payload.userId.trim() === '') return null;
 
 	return {
 		spaceName: payload.spaceName,
+		branch: payload.branch,
 		userId: payload.userId,
 	};
+}
+
+/**
+ * Path the preview cookie is scoped to. No trailing slash so it prefix-matches
+ * `/space/<name>/preview/<branch>/...` but not a sibling like `<branch>2`.
+ */
+export function buildSpacePreviewCookiePath(spaceName: string, branch: string): string {
+	return `/space/${encodeURIComponent(spaceName)}/preview/${encodeURIComponent(branch)}`;
+}
+
+/**
+ * Build the `Set-Cookie` value for the path-scoped HttpOnly preview cookie.
+ * - Separate preview domain (cross-site iframe): `SameSite=None; Secure; Partitioned`.
+ * - Same-origin (dev/main domain): `SameSite=Lax` (+ `Secure` when served over https).
+ */
+export function buildPreviewCookie(opts: {
+	token: string;
+	spaceName: string;
+	branch: string;
+	crossSite: boolean;
+	secure: boolean;
+	ttlSeconds?: number;
+}): string {
+	const { token, spaceName, branch, crossSite, secure } = opts;
+	const maxAge = opts.ttlSeconds ?? SPACE_PREVIEW_TOKEN_TTL_SECONDS;
+	const path = buildSpacePreviewCookiePath(spaceName, branch);
+	const parts = [
+		`${SPACE_PREVIEW_COOKIE_NAME}=${token}`,
+		`Path=${path}`,
+		`Max-Age=${maxAge}`,
+		'HttpOnly',
+	];
+	if (crossSite) {
+		parts.push('SameSite=None', 'Secure', 'Partitioned');
+	} else {
+		parts.push('SameSite=Lax');
+		if (secure) parts.push('Secure');
+	}
+	return parts.join('; ');
+}
+
+/** Read the raw preview-cookie value from a request's `Cookie` header. */
+export function readPreviewCookie(request: Request): string | null {
+	const header = request.headers.get('Cookie');
+	if (!header) return null;
+	for (const pair of header.split(';')) {
+		const idx = pair.indexOf('=');
+		if (idx === -1) continue;
+		const name = pair.slice(0, idx).trim();
+		if (name === SPACE_PREVIEW_COOKIE_NAME) {
+			return pair.slice(idx + 1).trim();
+		}
+	}
+	return null;
 }


### PR DESCRIPTION
- spacePreviewToken: add branch claim, 30m TTL, path-scoped HttpOnly cookie helpers
- think: always mint branch-scoped preview token
- space-preview: unify cookie-or-token handler, bootstrap cookie via ?t=, strip ?t= before forwarding
- index: route both domains through unified handler, credentialed CORS
- frontend: PreviewCompatBanner for Safari cross-domain previews with open-in-new-tab
- tests: token/cookie helpers, handler, registrable-domain heuristic