### PR TITLE
fix(udiff): insert diff replacement content literally (avoid $-substitution)

### DIFF
--- a/worker/agents/output-formats/diff-formats/udiff.test.ts
+++ b/worker/agents/output-formats/diff-formats/udiff.test.ts
@@ -354,4 +354,18 @@ stays the same`;
     const result = applyUnifiedDiff(original, diff);
     expect(result).toBe(expected);
   });
+
+  it('inserts $-sequences in replacement content literally ($&)', () => {
+    const original = `const a = 1;\nconst label = old;\nconst b = 2;`;
+    const diff = `@@ ... @@\n const a = 1;\n-const label = old;\n+const label = text.replace(/x/g, '[$&]');\n const b = 2;`;
+    const expected = `const a = 1;\nconst label = text.replace(/x/g, '[$&]');\nconst b = 2;`;
+    expect(applyUnifiedDiff(original, diff)).toBe(expected);
+  });
+
+  it('does not collapse $$ in replacement content', () => {
+    const original = `line1\nTODO\nline3`;
+    const diff = `@@ ... @@\n line1\n-TODO\n+const price = "$$5";\n line3`;
+    const expected = `line1\nconst price = "$$5";\nline3`;
+    expect(applyUnifiedDiff(original, diff)).toBe(expected);
+  });
 });

--- a/worker/agents/output-formats/diff-formats/udiff.ts
+++ b/worker/agents/output-formats/diff-formats/udiff.ts
@@ -169,7 +169,10 @@ function tryDirectApplication(content: string, hunk: string[]): string | null {
 
 	if (occurrences === 1) {
 		const afterBlock = after.join('\n');
-		return content.replace(beforeBlock, afterBlock);
+		// Use a replacer function so `$`-sequences in the generated replacement
+		// (e.g. `$&`, `$$`, `$1`) are inserted literally, not interpreted by
+		// String.prototype.replace.
+		return content.replace(beforeBlock, () => afterBlock);
 	}
 
 	// Strategy 2: Try with whitespace normalization
@@ -378,8 +381,9 @@ function tryWithNormalizedWhitespace(content: string, hunk: string[]): string | 
 		line.length > 0 ? actualIndentation + line : line
 	);
 	const replacementText = replacementLines.join('\n');
-	
-	return content.replace(matchedText, replacementText);
+
+	// Replacer function: insert the replacement literally (no `$`-pattern expansion).
+	return content.replace(matchedText, () => replacementText);
 }
 
 /**
@@ -550,7 +554,8 @@ function tryContextReduction(content: string, hunk: string[]): string | null {
 					...contextAfter,
 				]).after;
 				const replaceBlock = replaceAfter.join('\n');
-				return content.replace(searchBlock, replaceBlock);
+				// Replacer function: insert the replacement literally (no `$`-pattern expansion).
+				return content.replace(searchBlock, () => replaceBlock);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`applyDiff` (`worker/agents/output-formats/diff-formats/udiff.ts`) applies hunks with:

```ts
return content.replace(beforeBlock, afterBlock);
```

where `afterBlock` is the LLM-generated **replacement code**. `String.prototype.replace` with a **string** replacement interprets `$` sequences specially — `$&` → the whole match, `$$` → `$`, `` $`/$'/$1 `` → surrounding/captured text. So whenever generated code contains those tokens (extremely common in a webapp builder: ``text.replace(/x/g, '[$&]')``, price strings like `"$$5"`, jQuery `$$`, regex escaping, etc.), the applied diff **silently corrupts the file**.

`applyDiff` is the diff applier consumed by `scof.ts` and re-exported as `applyUnifiedDiff`, so this affects real generated edits. Three replacement sites are affected (the exact-match, indentation-normalized, and fuzzy-match paths).

Reproduction against the current `applyDiff`:

```
input replacement: const label = text.replace(/x/g, '[$&]');
got:               const label = text.replace(/x/g, '[const a = 1;\nconst label = old;\nconst b = 2;]');   // $& expanded to the whole match
input replacement: const price = "$$5";
got:               const price = "$5";                                                                      // $$ collapsed to $
```

## Fix

Pass a **replacer function** at the three sites so the replacement is inserted verbatim (a function return value is never `$`-interpreted):

```diff
-return content.replace(beforeBlock, afterBlock);
+return content.replace(beforeBlock, () => afterBlock);
```
(same change for `matchedText/replacementText` and `searchBlock/replaceBlock`).

## Testing

Added two regression tests to `udiff.test.ts` (`$&` and `$$` in replacement content). They fail on `main` (the two new cases) and pass with the fix:

```
vitest run worker/agents/output-formats/diff-formats/udiff.test.ts
✓ 15 passed | 1 skipped
```
(All pre-existing udiff tests still pass; the two new cases fail without the fix.)
