### PR TITLE
fix(space): strip Service-Worker-Allowed from preview responses

### DIFF
--- a/space/src/space/durable-object.ts
+++ b/space/src/space/durable-object.ts
@@ -15,6 +15,7 @@ import {
   buildInspectorWrapperSource,
   VIBE_APP_MODULE,
 } from "./inspector-wrapper"
+import { stripPreviewSecurityHeaders } from "./preview-headers"
 
 // ─── Inspector result types ────────────────────────────────────────────────
 // These mirror the shapes returned by the wrapper-subclass injected into
@@ -542,9 +543,14 @@ export class SpaceDO extends DurableObject<Env> {
       const previewRequest = new Request(previewUrl.toString(), request)
       const response = await this.servePreview(branch, previewRequest)
 
+      // Strip headers a generated app must not be able to set on the shared
+      // preview origin (e.g. Service-Worker-Allowed scope expansion) before
+      // any further rewriting.
+      const safeResponse = stripPreviewSecurityHeaders(response)
+
       // Rewrite root-relative paths in HTML responses so they resolve
       // correctly when the preview is mounted on a sub-path
-      return rewritePreviewResponse(response, basePath)
+      return rewritePreviewResponse(safeResponse, basePath)
     }
 
     const gitCtx: GitHttpContext = {

--- a/space/src/space/preview-headers.test.ts
+++ b/space/src/space/preview-headers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { stripPreviewSecurityHeaders, STRIPPED_PREVIEW_HEADERS } from './preview-headers'
+
+describe('stripPreviewSecurityHeaders', () => {
+  it('removes Service-Worker-Allowed from a JS (sw.js) response without altering body/status', async () => {
+    const res = new Response('self.addEventListener("fetch", () => {})', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/javascript',
+        'Service-Worker-Allowed': '/',
+      },
+    })
+
+    const safe = stripPreviewSecurityHeaders(res)
+
+    expect(safe.headers.get('Service-Worker-Allowed')).toBeNull()
+    expect(safe.headers.get('Content-Type')).toBe('application/javascript')
+    expect(safe.status).toBe(200)
+    expect(await safe.text()).toBe('self.addEventListener("fetch", () => {})')
+  })
+
+  it('removes every stripped header, including case-insensitive variants', () => {
+    const res = new Response('ok', {
+      headers: {
+        'service-worker-allowed': '/',
+        'Service-Worker-Navigation-Preload': 'true',
+        'clear-site-data': '"*"',
+        'X-Keep': 'yes',
+      },
+    })
+
+    const safe = stripPreviewSecurityHeaders(res)
+
+    for (const name of STRIPPED_PREVIEW_HEADERS) {
+      expect(safe.headers.get(name)).toBeNull()
+    }
+    expect(safe.headers.get('X-Keep')).toBe('yes')
+  })
+
+  it('returns the same response instance when no stripped headers are present', () => {
+    const res = new Response('hello', { headers: { 'Content-Type': 'text/html' } })
+    expect(stripPreviewSecurityHeaders(res)).toBe(res)
+  })
+
+  it('passes WebSocket upgrade responses through untouched', () => {
+    // Upgrade responses cannot be reconstructed; must be returned as-is even if
+    // they (defensively) carry a stripped header.
+    const res = new Response('ok', {
+      headers: { Upgrade: 'websocket', 'Service-Worker-Allowed': '/' },
+    })
+    const out = stripPreviewSecurityHeaders(res)
+    expect(out).toBe(res)
+    expect(out.headers.get('Service-Worker-Allowed')).toBe('/')
+  })
+})

--- a/space/src/space/preview-headers.ts
+++ b/space/src/space/preview-headers.ts
@@ -1,0 +1,38 @@
+// Preview response security.
+//
+// All Think previews share one browser origin (path-based on the preview
+// domain). A generated app must not be able to emit response headers that grant
+// it authority over that shared origin. Most importantly Service-Worker-Allowed
+// lets a service worker widen its scope to "/" - allowing one app's SW to
+// intercept every other user's previews. We also drop Clear-Site-Data (could
+// wipe other users' preview cookies) and Service-Worker-Navigation-Preload.
+
+export const STRIPPED_PREVIEW_HEADERS = [
+  "Service-Worker-Allowed",
+  "Service-Worker-Navigation-Preload",
+  "Clear-Site-Data",
+] as const
+
+export function stripPreviewSecurityHeaders(response: Response): Response {
+  // WebSocket upgrade responses cannot be reconstructed (no body, immutable
+  // headers); they never carry these headers, so pass them through untouched.
+  if (response.status === 101 || response.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    return response
+  }
+
+  const headers = new Headers(response.headers)
+  let changed = false
+  for (const name of STRIPPED_PREVIEW_HEADERS) {
+    if (headers.has(name)) {
+      headers.delete(name)
+      changed = true
+    }
+  }
+  if (!changed) return response
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}


### PR DESCRIPTION
Think previews share one browser origin (path-based on the preview domain). A generated app could emit Service-Worker-Allowed: / and have it passed through unfiltered, letting its service worker claim root scope and intercept every other user's previews (token theft, response forgery).

Strip Service-Worker-Allowed, Service-Worker-Navigation-Preload, and Clear-Site-Data from preview responses at the SpaceDO chokepoint so a SW can no longer escape its own preview path. WebSocket upgrades pass through untouched.

Ref: VULN-143611