### PR TITLE
[fix] Harden preview access: visibility gate, sandbox token verification, token revocation, and rate limiting

### DIFF
--- a/migrations/0006_gigantic_shinko_yamashiro.sql
+++ b/migrations/0006_gigantic_shinko_yamashiro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apps` ADD `preview_version` integer DEFAULT 0 NOT NULL;

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2666 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d5fd9fcc-906c-4a40-abfc-06c4aa9e20e2",
+  "prevId": "47bef73c-609f-49af-afc0-9deba2f38165",
+  "tables": {
+    "ai_gateways": {
+      "name": "ai_gateways",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloudflare_account_id": {
+          "name": "cloudflare_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gateway_name": {
+          "name": "gateway_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gateway_slug": {
+          "name": "gateway_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credits_remaining": {
+          "name": "credits_remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "credits_last_updated": {
+          "name": "credits_last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_created": {
+          "name": "auto_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ai_gateways_user_idx": {
+          "name": "ai_gateways_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_gateways_account_idx": {
+          "name": "ai_gateways_account_idx",
+          "columns": [
+            "cloudflare_account_id"
+          ],
+          "isUnique": false
+        },
+        "ai_gateways_user_account_idx": {
+          "name": "ai_gateways_user_account_idx",
+          "columns": [
+            "user_id",
+            "cloudflare_account_id"
+          ],
+          "isUnique": false
+        },
+        "ai_gateways_gateway_id_idx": {
+          "name": "ai_gateways_gateway_id_idx",
+          "columns": [
+            "cloudflare_account_id",
+            "gateway_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ai_gateways_user_id_users_id_fk": {
+          "name": "ai_gateways_user_id_users_id_fk",
+          "tableFrom": "ai_gateways",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_gateways_cloudflare_account_id_cloudflare_accounts_id_fk": {
+          "name": "ai_gateways_cloudflare_account_id_cloudflare_accounts_id_fk",
+          "tableFrom": "ai_gateways",
+          "tableTo": "cloudflare_accounts",
+          "columnsFrom": [
+            "cloudflare_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "api_keys_is_active_idx": {
+          "name": "api_keys_is_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "api_keys_expires_at_idx": {
+          "name": "api_keys_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_comments": {
+      "name": "app_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "app_comments_app_idx": {
+          "name": "app_comments_app_idx",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "app_comments_user_idx": {
+          "name": "app_comments_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "app_comments_parent_idx": {
+          "name": "app_comments_parent_idx",
+          "columns": [
+            "parent_comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "app_comments_app_id_apps_id_fk": {
+          "name": "app_comments_app_id_apps_id_fk",
+          "tableFrom": "app_comments",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_comments_user_id_users_id_fk": {
+          "name": "app_comments_user_id_users_id_fk",
+          "tableFrom": "app_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_likes": {
+      "name": "app_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'like'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "app_likes_app_user_idx": {
+          "name": "app_likes_app_user_idx",
+          "columns": [
+            "app_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "app_likes_user_idx": {
+          "name": "app_likes_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "app_likes_app_id_apps_id_fk": {
+          "name": "app_likes_app_id_apps_id_fk",
+          "tableFrom": "app_likes",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_likes_user_id_users_id_fk": {
+          "name": "app_likes_user_id_users_id_fk",
+          "tableFrom": "app_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_views": {
+      "name": "app_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "app_views_app_idx": {
+          "name": "app_views_app_idx",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "app_views_user_idx": {
+          "name": "app_views_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "app_views_viewed_at_idx": {
+          "name": "app_views_viewed_at_idx",
+          "columns": [
+            "viewed_at"
+          ],
+          "isUnique": false
+        },
+        "app_views_app_viewed_at_idx": {
+          "name": "app_views_app_viewed_at_idx",
+          "columns": [
+            "app_id",
+            "viewed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "app_views_app_id_apps_id_fk": {
+          "name": "app_views_app_id_apps_id_fk",
+          "tableFrom": "app_views",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_views_user_id_users_id_fk": {
+          "name": "app_views_user_id_users_id_fk",
+          "tableFrom": "app_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_prompt": {
+          "name": "original_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_prompt": {
+          "name": "final_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "framework": {
+          "name": "framework",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generating'"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repository_url": {
+          "name": "github_repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repository_visibility": {
+          "name": "github_repository_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "parent_app_id": {
+          "name": "parent_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_version": {
+          "name": "preview_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "screenshot_url": {
+          "name": "screenshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshot_captured_at": {
+          "name": "screenshot_captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apps_user_idx": {
+          "name": "apps_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apps_status_idx": {
+          "name": "apps_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "apps_visibility_idx": {
+          "name": "apps_visibility_idx",
+          "columns": [
+            "visibility"
+          ],
+          "isUnique": false
+        },
+        "apps_session_token_idx": {
+          "name": "apps_session_token_idx",
+          "columns": [
+            "session_token"
+          ],
+          "isUnique": false
+        },
+        "apps_parent_app_idx": {
+          "name": "apps_parent_app_idx",
+          "columns": [
+            "parent_app_id"
+          ],
+          "isUnique": false
+        },
+        "apps_search_idx": {
+          "name": "apps_search_idx",
+          "columns": [
+            "title",
+            "description"
+          ],
+          "isUnique": false
+        },
+        "apps_framework_status_idx": {
+          "name": "apps_framework_status_idx",
+          "columns": [
+            "framework",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "apps_visibility_status_idx": {
+          "name": "apps_visibility_status_idx",
+          "columns": [
+            "visibility",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "apps_created_at_idx": {
+          "name": "apps_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "apps_updated_at_idx": {
+          "name": "apps_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apps_user_id_users_id_fk": {
+          "name": "apps_user_id_users_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_idx": {
+          "name": "audit_logs_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_entity_idx": {
+          "name": "audit_logs_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_attempts": {
+      "name": "auth_attempts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "auth_attempts_lookup_idx": {
+          "name": "auth_attempts_lookup_idx",
+          "columns": [
+            "identifier",
+            "attempted_at"
+          ],
+          "isUnique": false
+        },
+        "auth_attempts_ip_idx": {
+          "name": "auth_attempts_ip_idx",
+          "columns": [
+            "ip_address",
+            "attempted_at"
+          ],
+          "isUnique": false
+        },
+        "auth_attempts_success_idx": {
+          "name": "auth_attempts_success_idx",
+          "columns": [
+            "success",
+            "attempted_at"
+          ],
+          "isUnique": false
+        },
+        "auth_attempts_type_idx": {
+          "name": "auth_attempts_type_idx",
+          "columns": [
+            "attempt_type",
+            "attempted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloudflare_accounts": {
+      "name": "cloudflare_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloudflare_accounts_user_idx": {
+          "name": "cloudflare_accounts_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "cloudflare_accounts_account_id_idx": {
+          "name": "cloudflare_accounts_account_id_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "cloudflare_accounts_user_account_idx": {
+          "name": "cloudflare_accounts_user_account_idx",
+          "columns": [
+            "user_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_accounts_user_id_users_id_fk": {
+          "name": "cloudflare_accounts_user_id_users_id_fk",
+          "tableFrom": "cloudflare_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'like'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "comment_likes_comment_user_idx": {
+          "name": "comment_likes_comment_user_idx",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "comment_likes_user_idx": {
+          "name": "comment_likes_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "comment_likes_comment_idx": {
+          "name": "comment_likes_comment_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_app_comments_id_fk": {
+          "name": "comment_likes_comment_id_app_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "app_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_user_id_users_id_fk": {
+          "name": "comment_likes_user_id_users_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "email_verification_tokens_lookup_idx": {
+          "name": "email_verification_tokens_lookup_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        },
+        "email_verification_tokens_expiry_idx": {
+          "name": "email_verification_tokens_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "favorites_user_app_idx": {
+          "name": "favorites_user_app_idx",
+          "columns": [
+            "user_id",
+            "app_id"
+          ],
+          "isUnique": true
+        },
+        "favorites_user_idx": {
+          "name": "favorites_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "favorites_app_idx": {
+          "name": "favorites_app_idx",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_app_id_apps_id_fk": {
+          "name": "favorites_app_id_apps_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_states": {
+      "name": "oauth_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_used": {
+          "name": "is_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "columns": [
+            "state"
+          ],
+          "isUnique": true
+        },
+        "oauth_states_state_idx": {
+          "name": "oauth_states_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": true
+        },
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "password_reset_tokens_lookup_idx": {
+          "name": "password_reset_tokens_lookup_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        },
+        "password_reset_tokens_expiry_idx": {
+          "name": "password_reset_tokens_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_access_token_hash_idx": {
+          "name": "sessions_access_token_hash_idx",
+          "columns": [
+            "access_token_hash"
+          ],
+          "isUnique": false
+        },
+        "sessions_refresh_token_hash_idx": {
+          "name": "sessions_refresh_token_hash_idx",
+          "columns": [
+            "refresh_token_hash"
+          ],
+          "isUnique": false
+        },
+        "sessions_last_activity_idx": {
+          "name": "sessions_last_activity_idx",
+          "columns": [
+            "last_activity"
+          ],
+          "isUnique": false
+        },
+        "sessions_is_revoked_idx": {
+          "name": "sessions_is_revoked_idx",
+          "columns": [
+            "is_revoked"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stars": {
+      "name": "stars",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starred_at": {
+          "name": "starred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "stars_user_app_idx": {
+          "name": "stars_user_app_idx",
+          "columns": [
+            "user_id",
+            "app_id"
+          ],
+          "isUnique": true
+        },
+        "stars_user_idx": {
+          "name": "stars_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "stars_app_idx": {
+          "name": "stars_app_idx",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "stars_app_starred_at_idx": {
+          "name": "stars_app_starred_at_idx",
+          "columns": [
+            "app_id",
+            "starred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stars_user_id_users_id_fk": {
+          "name": "stars_user_id_users_id_fk",
+          "tableFrom": "stars",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stars_app_id_apps_id_fk": {
+          "name": "stars_app_id_apps_id_fk",
+          "tableFrom": "stars",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "system_settings_key_unique": {
+          "name": "system_settings_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "system_settings_key_idx": {
+          "name": "system_settings_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model_configs": {
+      "name": "user_model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_action_name": {
+          "name": "agent_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_override": {
+          "name": "provider_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_model_configs_user_agent_idx": {
+          "name": "user_model_configs_user_agent_idx",
+          "columns": [
+            "user_id",
+            "agent_action_name"
+          ],
+          "isUnique": true
+        },
+        "user_model_configs_user_idx": {
+          "name": "user_model_configs_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_model_configs_is_active_idx": {
+          "name": "user_model_configs_is_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_model_configs_user_id_users_id_fk": {
+          "name": "user_model_configs_user_id_users_id_fk",
+          "tableFrom": "user_model_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model_providers": {
+      "name": "user_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_model_providers_user_name_idx": {
+          "name": "user_model_providers_user_name_idx",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "user_model_providers_user_idx": {
+          "name": "user_model_providers_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_model_providers_is_active_idx": {
+          "name": "user_model_providers_is_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_model_providers_user_id_users_id_fk": {
+          "name": "user_model_providers_user_id_users_id_fk",
+          "tableFrom": "user_model_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_changed_at": {
+          "name": "password_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_provider_unique_idx": {
+          "name": "users_provider_unique_idx",
+          "columns": [
+            "provider",
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "users_failed_login_attempts_idx": {
+          "name": "users_failed_login_attempts_idx",
+          "columns": [
+            "failed_login_attempts"
+          ],
+          "isUnique": false
+        },
+        "users_locked_until_idx": {
+          "name": "users_locked_until_idx",
+          "columns": [
+            "locked_until"
+          ],
+          "isUnique": false
+        },
+        "users_is_active_idx": {
+          "name": "users_is_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "users_last_active_at_idx": {
+          "name": "users_last_active_at_idx",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification_otps": {
+      "name": "verification_otps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "otp": {
+          "name": "otp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "verification_otps_email_idx": {
+          "name": "verification_otps_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "verification_otps_expires_at_idx": {
+          "name": "verification_otps_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "verification_otps_used_idx": {
+          "name": "verification_otps_used_idx",
+          "columns": [
+            "used"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777015990625,
       "tag": "0005_cloudflare_oauth_connect",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1783335505960,
+      "tag": "0006_gigantic_shinko_yamashiro",
+      "breakpoints": true
     }
   ]
 }

--- a/space/src/space/durable-object.ts
+++ b/space/src/space/durable-object.ts
@@ -61,12 +61,25 @@ interface DeploymentRow {
 // The host worker calls methods via DO RPC (same worker, no HTTP).
 // External git clients can use Smart HTTP via the forwarded routes.
 
+// Built asset manifest + in-memory storage for a single deployment. Rebuilding
+// these on every request is wasteful (CWE-770 amplification under a preview
+// flood), so we cache them per `branch:commitHash` with an LRU + TTL bound.
+type CachedAssets = {
+  manifest: Awaited<ReturnType<typeof buildAssetManifest>>
+  storage: ReturnType<typeof createMemoryStorage>
+  expiresAt: number
+}
+const ASSET_CACHE_MAX_ENTRIES = 8
+const ASSET_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
 export class SpaceDO extends DurableObject<Env> {
   private workspace: Workspace
   private fs: WorkspaceFileSystem
   private git: Git
   private stateBackend: FileSystemStateBackend
   private initialized = false
+  // Keyed by `${branch}:${commitHash}` — commitHash makes redeploys self-invalidate.
+  private assetCache = new Map<string, CachedAssets>()
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env)
@@ -406,10 +419,11 @@ export class SpaceDO extends DurableObject<Env> {
       return new Response(`No deployment found for branch "${branch}"`, { status: 404 })
     }
 
-    // Serve static assets host-side before forwarding to the Facet.
+    // Serve static assets host-side before forwarding to the Facet. The built
+    // manifest/storage are cached per deployment so repeat asset reads don't
+    // re-spin the build on every request.
     if (Object.keys(dep.assets).length > 0) {
-      const manifest = await buildAssetManifest(dep.assets)
-      const storage = createMemoryStorage(dep.assets)
+      const { manifest, storage } = await this.getCachedAssets(dep)
       const assetResponse = await handleAssetRequest(request, manifest, storage, dep.assetConfig)
       if (assetResponse) return assetResponse
     }
@@ -426,6 +440,42 @@ export class SpaceDO extends DurableObject<Env> {
 
     const facet = this.ctx.facets.get(facetNameForApp(branch), () => ({ class: appClass }))
     return facet.fetch(request)
+  }
+
+  /**
+   * Return the built asset manifest + in-memory storage for a deployment,
+   * reusing a cached build when available. Keyed by `branch:commitHash` so a
+   * redeploy (new commit) transparently rebuilds. Bounded by an LRU cap + TTL.
+   */
+  private async getCachedAssets(dep: DeploymentRow): Promise<CachedAssets> {
+    const key = `${dep.branch}:${dep.commitHash}`
+    const now = Date.now()
+
+    const cached = this.assetCache.get(key)
+    if (cached && cached.expiresAt > now) {
+      // Refresh LRU recency.
+      this.assetCache.delete(key)
+      this.assetCache.set(key, cached)
+      return cached
+    }
+
+    const manifest = await buildAssetManifest(dep.assets)
+    const storage = createMemoryStorage(dep.assets)
+    const entry: CachedAssets = { manifest, storage, expiresAt: now + ASSET_CACHE_TTL_MS }
+
+    this.assetCache.set(key, entry)
+
+    // Evict expired / oldest entries to keep the cache bounded.
+    for (const [k, v] of this.assetCache) {
+      if (v.expiresAt <= now) this.assetCache.delete(k)
+    }
+    while (this.assetCache.size > ASSET_CACHE_MAX_ENTRIES) {
+      const oldest = this.assetCache.keys().next().value
+      if (oldest === undefined) break
+      this.assetCache.delete(oldest)
+    }
+
+    return entry
   }
 
   // ── App-class loader ────────────────────────────────────────────

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -38,7 +38,8 @@ export type {
   AppDetailsData,
   AppStarToggleData,
   GeneratedCodeFile,
-  GitCloneTokenData
+  GitCloneTokenData,
+  PreviewTokenData
 } from 'worker/api/controllers/appView/types';
 
 // User-related API Types

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -15,6 +15,7 @@ import type{
 	AppDetailsData,
 	AppStarToggleData,
 	GitCloneTokenData,
+	PreviewTokenData,
 	UserAppsData,
 	ProfileUpdateData,
 	UserStatsData,
@@ -558,6 +559,18 @@ class ApiClient {
 		appId: string,
 	): Promise<ApiResponse<GitCloneTokenData>> {
 		return this.request<GitCloneTokenData>(`/api/apps/${appId}/git/token`, {
+			method: 'POST',
+		});
+	}
+
+	/**
+	 * Generate a short-lived owner-preview token so the owner can open a
+	 * private deployed app's URL on a preview subdomain.
+	 */
+	async generatePreviewToken(
+		appId: string,
+	): Promise<ApiResponse<PreviewTokenData>> {
+		return this.request<PreviewTokenData>(`/api/apps/${appId}/preview-token`, {
 			method: 'POST',
 		});
 	}

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -101,6 +101,9 @@ export default function AppView() {
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [isGitCloneModalOpen, setIsGitCloneModalOpen] = useState(false);
 	const [activeFilePath, setActiveFilePath] = useState<string>();
+	// For a PRIVATE deployed app, the owner needs a deployment-scoped token to
+	// open the preview subdomain (main-domain session cookies aren't sent there).
+	const [ownerPreviewUrl, setOwnerPreviewUrl] = useState<string | null>(null);
 	const previewIframeRef = useRef<HTMLIFrameElement>(null);
 
 	const fetchAppDetails = useCallback(async () => {
@@ -144,6 +147,38 @@ export default function AppView() {
 	useEffect(() => {
 		fetchAppDetails();
 	}, [id, fetchAppDetails]);
+
+	// Mint an owner-preview token when the owner views their own PRIVATE deployed
+	// app, so the preview iframe / open-in-new-tab can reach the gated subdomain.
+	useEffect(() => {
+		let cancelled = false;
+		const needsToken =
+			!!app &&
+			!!user &&
+			app.userId === user.id &&
+			app.visibility === 'private' &&
+			!!app.deploymentId;
+
+		if (!needsToken) {
+			setOwnerPreviewUrl(null);
+			return;
+		}
+
+		(async () => {
+			try {
+				const response = await apiClient.generatePreviewToken(app!.id);
+				if (!cancelled && response.success && response.data) {
+					setOwnerPreviewUrl(response.data.previewUrl);
+				}
+			} catch (err) {
+				console.error('Failed to generate owner preview token:', err);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [app, user]);
 
 
 	// Convert agent files to chat FileType format
@@ -380,7 +415,9 @@ export default function AppView() {
 	};
 
 	const getAppUrl = () => {
-		return app?.cloudflareUrl || app?.previewUrl || '';
+		// Prefer the tokenized owner-preview URL for a private deployed app the
+		// owner is viewing; otherwise the plain deployed/preview URL.
+		return ownerPreviewUrl || app?.cloudflareUrl || app?.previewUrl || '';
 	};
 
 	const handlePreviewDeploy = async () => {

--- a/src/routes/chat/components/deployment-controls.tsx
+++ b/src/routes/chat/components/deployment-controls.tsx
@@ -113,6 +113,31 @@ export function DeploymentControls({
 		onDeploy(instanceId);
 	};
 
+	const handleViewLive = async () => {
+		if (!deploymentUrl) return;
+
+		// Public apps (or missing appId): open the deployed URL directly.
+		if (localVisibility !== 'private' || !appId) {
+			window.open(deploymentUrl, '_blank');
+			return;
+		}
+
+		// Private apps are gated at the dispatch layer, so mint a short-lived,
+		// deployment-scoped owner-preview token and open the tokenized URL.
+		try {
+			const response = await apiClient.generatePreviewToken(appId);
+			if (response.success && response.data) {
+				window.open(response.data.previewUrl, '_blank');
+				return;
+			}
+		} catch (error) {
+			console.error('Failed to generate owner preview token:', error);
+		}
+
+		// Fallback: attempt the raw URL.
+		window.open(deploymentUrl, '_blank');
+	};
+
 	const handleToggleVisibility = async () => {
 		if (!appId) {
 			toast.error('App ID not found');
@@ -358,7 +383,7 @@ export function DeploymentControls({
 					)}>
 						{/* View Live Site Button */}
 						<Button
-							onClick={() => deploymentUrl && window.open(deploymentUrl, '_blank')}
+							onClick={handleViewLive}
 							variant="primary"
 							className="h-10 text-sm bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white border-green-600 dark:border-green-700 font-medium shadow-sm hover:shadow-md dark:hover:shadow-green-900/50 transition-all duration-200 hover:scale-[1.02]"
 						>

--- a/worker/agents/core/behaviors/think.ts
+++ b/worker/agents/core/behaviors/think.ts
@@ -22,6 +22,7 @@ import {
 } from 'worker/utils/urls';
 import { isDev } from 'worker/utils/envs';
 import { signSpacePreviewToken } from 'worker/utils/spacePreviewToken';
+import { AppService } from 'worker/database/services/AppService';
 import { AGENT_CONFIG } from '../../inferutils/config';
 import { AI_MODEL_CONFIG, AIModels, AIModelConfig, ModelSize } from '../../inferutils/config.types';
 import { getConfigurationForModel } from '../../inferutils/core';
@@ -349,10 +350,15 @@ export class ThinkCodingBehavior
 		// path-scoped HttpOnly preview cookie on first load (so iframe sub-resources
 		// authenticate), and authenticates machine clients like the headless
 		// `get_browser_console_logs` browser, which carry no cookie.
+		// Embed the app's current preview-token revocation epoch so a later
+		// visibility toggle (which bumps it) invalidates this token.
+		const previewVersion =
+			(await new AppService(this.env).getPreviewVersion(spaceName)) ?? 0;
 		const token = await signSpacePreviewToken(this.env, {
 			spaceName,
 			branch,
 			userId: this.state.metadata.userId,
+			previewVersion,
 		});
 		return `${previewBaseUrl}?t=${encodeURIComponent(token)}`;
 	}

--- a/worker/api/controllers/agent/controller.ts
+++ b/worker/api/controllers/agent/controller.ts
@@ -422,7 +422,20 @@ export class CodingAgentController extends BaseController {
                 return CodingAgentController.createErrorResponse<AgentPreviewResponse>('App not found', 404);
             }
 
-            // Check if app is public
+            // Visibility gate (intentional design — not an authorization gap):
+            //  - PRIVATE apps: owner-only (any non-owner gets 403 below).
+            //  - PUBLIC apps: any authenticated user may spin up an ephemeral
+            //    *sandbox* preview. This is deliberate: publishing is decoupled
+            //    from production deploy, and viewer-triggered previews are the
+            //    intended way to preview public apps that were never deployed.
+            //
+            // This action is SANDBOX-ONLY: deployToSandbox() never mutates the
+            // owner's production deploy state (deploymentId / dispatch worker),
+            // and the request passes through the global + per-user auth rate
+            // limiters. The credential-theft chain historically associated with
+            // this endpoint (reading .dev.vars via the sandbox control plane on
+            // port 3000) is closed in worker/services/sandbox/request-handler.ts,
+            // which blocks control-plane ports and verifies per-port tokens.
             if(appResult.visibility !== 'public') {
                 // If user is logged in and is the owner, allow preview deployment
                 const user = context.user;

--- a/worker/api/controllers/appView/controller.ts
+++ b/worker/api/controllers/appView/controller.ts
@@ -8,11 +8,17 @@ import {
     AppDetailsData, 
     AppStarToggleData,
     GitCloneTokenData,
+    PreviewTokenData,
 } from './types';
 import { AgentSummary } from '../../../agents/core/types';
 import { createLogger } from '../../../logger';
 import { buildUserWorkerUrl, buildGitCloneUrl } from 'worker/utils/urls';
 import { JWTUtils } from '../../../utils/jwtUtils';
+import {
+    OWNER_PREVIEW_QUERY_PARAM,
+    OWNER_PREVIEW_TOKEN_TTL_SECONDS,
+    signOwnerPreviewToken,
+} from '../../../utils/ownerPreviewToken';
 
 export class AppViewController extends BaseController {
     static logger = createLogger('AppViewController');
@@ -202,6 +208,61 @@ export class AppViewController extends BaseController {
         } catch (error) {
             this.logger.error('Error generating git clone token:', error);
             return AppViewController.createErrorResponse<GitCloneTokenData>('Failed to generate token', 500);
+        }
+    }
+
+    /**
+     * Generate a short-lived, deployment-scoped owner-preview token so the owner
+     * can open a PRIVATE deployed app's URL on a preview subdomain (where the
+     * main-domain session cookie is not sent).
+     * POST /api/apps/:id/preview-token  (OWNER ONLY)
+     */
+    static async generatePreviewToken(
+        _request: Request,
+        env: Env,
+        _ctx: ExecutionContext,
+        context: RouteContext
+    ): Promise<ControllerResponse<ApiResponse<PreviewTokenData>>> {
+        try {
+            const user = context.user!;
+            const appId = context.pathParams.id;
+
+            if (!appId) {
+                return AppViewController.createErrorResponse<PreviewTokenData>('App ID is required', 400);
+            }
+
+            const appService = new AppService(env);
+            const app = await appService.getAppDetails(appId, user.id);
+
+            if (!app) {
+                return AppViewController.createErrorResponse<PreviewTokenData>('App not found', 404);
+            }
+            if (app.userId !== user.id) {
+                return AppViewController.createErrorResponse<PreviewTokenData>('App not found', 404);
+            }
+            if (!app.deploymentId) {
+                return AppViewController.createErrorResponse<PreviewTokenData>('App is not deployed', 400);
+            }
+
+            const token = await signOwnerPreviewToken(env, {
+                userId: user.id,
+                deploymentId: app.deploymentId,
+            });
+
+            const base = buildUserWorkerUrl(env, app.deploymentId);
+            const previewUrl = `${base}/?${OWNER_PREVIEW_QUERY_PARAM}=${encodeURIComponent(token)}`;
+
+            const responseData: PreviewTokenData = {
+                token,
+                expiresIn: OWNER_PREVIEW_TOKEN_TTL_SECONDS,
+                expiresAt: new Date(Date.now() + OWNER_PREVIEW_TOKEN_TTL_SECONDS * 1000).toISOString(),
+                previewUrl,
+            };
+
+            return AppViewController.createSuccessResponse(responseData);
+        } catch (error) {
+            this.logger.error('Error generating preview token:', error);
+            return AppViewController.createErrorResponse<PreviewTokenData>('Failed to generate token', 500);
         }
     }
 

--- a/worker/api/controllers/appView/types.ts
+++ b/worker/api/controllers/appView/types.ts
@@ -48,6 +48,18 @@ export interface GitCloneTokenData {
     cloneUrl: string;
 }
 
+/**
+ * Response data for owner-preview token generation. Lets the owner open a
+ * private deployed app's URL on a preview subdomain.
+ */
+export interface PreviewTokenData {
+    token: string;
+    expiresIn: number;
+    expiresAt: string;
+    /** Deployment URL with the owner-preview token appended. */
+    previewUrl: string;
+}
+
 // /**
 //  * Response data for forkApp
 //  */

--- a/worker/api/handlers/space-preview-ratelimit.test.ts
+++ b/worker/api/handlers/space-preview-ratelimit.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Import via the same specifier the handler uses so `instanceof` matches the
+// class identity inside space-preview.ts (Vite resolves the `shared` alias).
+import { RateLimitExceededError } from 'shared/types/errors';
+
+// getPreviewVersion is always 0 here (no visibility revocation under test).
+vi.mock('../../database/services/AppService', () => ({
+	AppService: class {
+		async getPreviewVersion() {
+			return 0;
+		}
+	},
+}));
+
+// Simulate the per-token limiter: allow up to LIMIT calls per token, then throw.
+const LIMIT = 3;
+const callsByToken = new Map<string, number>();
+vi.mock('../../services/rate-limit/rateLimits', () => ({
+	RateLimitService: {
+		enforceSpacePreviewRateLimit: async (
+			_env: unknown,
+			_config: unknown,
+			tokenId: string,
+		) => {
+			const n = (callsByToken.get(tokenId) ?? 0) + 1;
+			callsByToken.set(tokenId, n);
+			if (n > LIMIT) {
+				throw new RateLimitExceededError('Space preview rate limit exceeded', 'spacePreview');
+			}
+		},
+	},
+}));
+
+const { handleSpacePreview } = await import('./space-preview');
+const { signSpacePreviewToken } = await import('../../utils/spacePreviewToken');
+
+const JWT_SECRET = 'test-secret-for-space-preview-token-validation-1234567890';
+
+type HandlerEnv = Parameters<typeof handleSpacePreview>[1];
+
+function makeEnv(): HandlerEnv {
+	const stub = {
+		fetch: async () => new Response('ok', { headers: { 'content-type': 'text/html' } }),
+	};
+	return {
+		JWT_SECRET,
+		CUSTOM_DOMAIN: 'example.com',
+		CUSTOM_PREVIEW_DOMAIN: '',
+		SPACE_DO: { idFromName: (n: string) => n, get: () => stub },
+	} as unknown as HandlerEnv;
+}
+
+function previewRequest(token: string): Request {
+	return new Request(
+		`https://example.com/space/space-a/preview/main/?t=${encodeURIComponent(token)}`,
+	);
+}
+
+beforeEach(() => {
+	callsByToken.clear();
+});
+
+describe('handleSpacePreview rate limiting', () => {
+	it('returns 200 up to the limit then 429 for sustained same-token traffic', async () => {
+		const env = makeEnv();
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+			previewVersion: 0,
+		});
+		const req = () => handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
+
+		for (let i = 0; i < LIMIT; i++) {
+			expect((await req()).status).toBe(200);
+		}
+		// Over the limit.
+		expect((await req()).status).toBe(429);
+	});
+
+	it('counts distinct tokens separately', async () => {
+		const env = makeEnv();
+		const tokenA = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+			previewVersion: 0,
+		});
+		const tokenB = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-b',
+			previewVersion: 0,
+		});
+
+		// Exhaust token A.
+		for (let i = 0; i < LIMIT; i++) {
+			await handleSpacePreview(previewRequest(tokenA), env, 'space-a', 'main');
+		}
+		expect((await handleSpacePreview(previewRequest(tokenA), env, 'space-a', 'main')).status).toBe(429);
+		// Token B is unaffected.
+		expect((await handleSpacePreview(previewRequest(tokenB), env, 'space-a', 'main')).status).toBe(200);
+	});
+});

--- a/worker/api/handlers/space-preview.test.ts
+++ b/worker/api/handlers/space-preview.test.ts
@@ -1,12 +1,30 @@
-import { describe, expect, it } from 'vitest';
-import { handleSpacePreview } from './space-preview';
-import {
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The handler reads the app's current previewVersion via AppService. The test
+// env has no D1 binding, so mock it with a controllable value (bumping it
+// simulates a visibility toggle). This also avoids loading AppService's heavy
+// DB dependencies in the worker test isolate.
+let currentPreviewVersion = 0;
+vi.mock('../../database/services/AppService', () => ({
+	AppService: class {
+		async getPreviewVersion() {
+			return currentPreviewVersion;
+		}
+	},
+}));
+
+const { handleSpacePreview } = await import('./space-preview');
+const {
 	buildPreviewCookie,
 	signSpacePreviewToken,
 	SPACE_PREVIEW_COOKIE_NAME,
-} from '../../utils/spacePreviewToken';
+} = await import('../../utils/spacePreviewToken');
 
 const JWT_SECRET = 'test-secret-for-space-preview-token-validation-1234567890';
+
+beforeEach(() => {
+	currentPreviewVersion = 0;
+});
 
 type HandlerEnv = Parameters<typeof handleSpacePreview>[1];
 
@@ -53,6 +71,7 @@ describe('handleSpacePreview', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 
 		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
@@ -70,6 +89,7 @@ describe('handleSpacePreview', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 		const cookie = buildPreviewCookie({
 			token,
@@ -100,10 +120,32 @@ describe('handleSpacePreview', () => {
 			spaceName: 'space-a',
 			branch: 'feature',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 
 		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');
 		expect(res.status).toBe(401);
+	});
+
+	it('rejects a token after the app previewVersion is bumped (visibility toggle)', async () => {
+		const env = makeEnv();
+		const token = await signSpacePreviewToken(env, {
+			spaceName: 'space-a',
+			branch: 'main',
+			userId: 'user-a',
+			previewVersion: 0,
+		});
+
+		// Minted at version 0 — accepted while the app is still at version 0.
+		expect(
+			(await handleSpacePreview(previewRequest(token), env, 'space-a', 'main')).status,
+		).toBe(200);
+
+		// A visibility toggle bumps previewVersion; the same token is now stale.
+		currentPreviewVersion = 1;
+		expect(
+			(await handleSpacePreview(previewRequest(token), env, 'space-a', 'main')).status,
+		).toBe(401);
 	});
 
 	it('on a separate preview domain, sets a partitioned cookie and strips ?t= before forwarding', async () => {
@@ -113,6 +155,7 @@ describe('handleSpacePreview', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 
 		const res = await handleSpacePreview(previewRequest(token), env, 'space-a', 'main');

--- a/worker/api/handlers/space-preview.ts
+++ b/worker/api/handlers/space-preview.ts
@@ -6,6 +6,10 @@ import {
 } from '../../utils/spacePreviewToken';
 import { isSeparatePreviewDomain } from '../../utils/urls';
 import { AppService } from '../../database/services/AppService';
+import { RateLimitService } from '../../services/rate-limit/rateLimits';
+import { getGlobalConfigurableSettings } from '../../config';
+import { RateLimitExceededError } from 'shared/types/errors';
+import { JWTUtils } from '../../utils/jwtUtils';
 
 const SPACE_PREVIEW_ROUTE_PATTERN = /^\/space\/([^/]+)\/preview\/([^/]+)(?:\/.*)?$/;
 
@@ -61,7 +65,7 @@ async function forwardToSpacePreview(
 	}
 }
 
-export function createPreviewAccessResponse(status: 401 | 403, title: string, message: string): Response {
+export function createPreviewAccessResponse(status: 401 | 403 | 429, title: string, message: string): Response {
 	return new Response(
 		`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${title}</title><style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b1020;color:#e5e7eb;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:24px}.card{max-width:480px;background:#111827;border:1px solid #374151;border-radius:12px;padding:24px;box-shadow:0 20px 45px rgba(0,0,0,.35)}h1{margin:0 0 12px;font-size:24px}p{margin:0;color:#cbd5e1;line-height:1.5}</style></head><body><div class="card"><h1>${title}</h1><p>${message}</p></div></body></html>`,
 		{
@@ -93,6 +97,31 @@ async function isPreviewVersionCurrent(
 }
 
 /**
+ * Enforce a per-preview-token rate limit. SpaceDO previews are dispatched
+ * outside the Hono chain, so the global API limiter does not apply here.
+ * Returns a `429` Response when the limit is exceeded, otherwise `null`.
+ * The limiter is keyed by a hash of the token (never the raw token).
+ */
+async function enforcePreviewRateLimit(
+	env: Env,
+	token: string,
+	request: Request,
+): Promise<Response | null> {
+	try {
+		const config = await getGlobalConfigurableSettings(env);
+		const tokenId = await JWTUtils.getInstance(env).hashToken(token);
+		await RateLimitService.enforceSpacePreviewRateLimit(env, config.security.rateLimit, tokenId, request);
+		return null;
+	} catch (error) {
+		if (error instanceof RateLimitExceededError) {
+			return createPreviewAccessResponse(429, 'Too many requests', 'This preview is receiving too many requests. Please slow down and try again shortly.');
+		}
+		// Fail open on unexpected limiter errors — do not block a legit preview.
+		return null;
+	}
+}
+
+/**
  * Unified, token-only preview auth. A request is authorized if it carries a
  * valid path/branch-scoped preview cookie, or a valid `?t=` token (which then
  * bootstraps the cookie). No session cookie / DB ownership check (claims-only),
@@ -113,6 +142,8 @@ export async function handleSpacePreview(
 	if (cookieToken) {
 		const claims = await verifySpacePreviewToken(env, cookieToken, spaceName, branch);
 		if (claims && (await isPreviewVersionCurrent(env, spaceName, claims))) {
+			const limited = await enforcePreviewRateLimit(env, cookieToken, request);
+			if (limited) return limited;
 			return forwardToSpacePreview(request, env, spaceName);
 		}
 	}
@@ -122,6 +153,8 @@ export async function handleSpacePreview(
 	if (queryToken) {
 		const claims = await verifySpacePreviewToken(env, queryToken, spaceName, branch);
 		if (claims && (await isPreviewVersionCurrent(env, spaceName, claims))) {
+			const limited = await enforcePreviewRateLimit(env, queryToken, request);
+			if (limited) return limited;
 			const response = await forwardToSpacePreview(request, env, spaceName);
 			if (isWebSocketResponse(response)) {
 				return response;

--- a/worker/api/handlers/space-preview.ts
+++ b/worker/api/handlers/space-preview.ts
@@ -2,8 +2,10 @@ import {
 	buildPreviewCookie,
 	readPreviewCookie,
 	verifySpacePreviewToken,
+	type SpacePreviewClaims,
 } from '../../utils/spacePreviewToken';
 import { isSeparatePreviewDomain } from '../../utils/urls';
+import { AppService } from '../../database/services/AppService';
 
 const SPACE_PREVIEW_ROUTE_PATTERN = /^\/space\/([^/]+)\/preview\/([^/]+)(?:\/.*)?$/;
 
@@ -76,9 +78,25 @@ function isWebSocketResponse(response: Response): boolean {
 }
 
 /**
+ * Confirm the token's embedded `previewVersion` still matches the app's current
+ * value. A visibility toggle bumps `previewVersion` (see AppService), so a token
+ * minted while public is rejected after a public->private toggle. Read from the
+ * primary DB (no cache) for ~1s revocation. `spaceName === appId`.
+ */
+async function isPreviewVersionCurrent(
+	env: Env,
+	spaceName: string,
+	claims: SpacePreviewClaims,
+): Promise<boolean> {
+	const current = (await new AppService(env).getPreviewVersion(spaceName)) ?? 0;
+	return current === claims.previewVersion;
+}
+
+/**
  * Unified, token-only preview auth. A request is authorized if it carries a
  * valid path/branch-scoped preview cookie, or a valid `?t=` token (which then
- * bootstraps the cookie). No session cookie / DB ownership check (claims-only).
+ * bootstraps the cookie). No session cookie / DB ownership check (claims-only),
+ * but the token's `previewVersion` must still match the app's current epoch.
  */
 export async function handleSpacePreview(
 	request: Request,
@@ -94,7 +112,7 @@ export async function handleSpacePreview(
 	const cookieToken = readPreviewCookie(request);
 	if (cookieToken) {
 		const claims = await verifySpacePreviewToken(env, cookieToken, spaceName, branch);
-		if (claims) {
+		if (claims && (await isPreviewVersionCurrent(env, spaceName, claims))) {
 			return forwardToSpacePreview(request, env, spaceName);
 		}
 	}
@@ -103,7 +121,7 @@ export async function handleSpacePreview(
 	const queryToken = url.searchParams.get('t') ?? '';
 	if (queryToken) {
 		const claims = await verifySpacePreviewToken(env, queryToken, spaceName, branch);
-		if (claims) {
+		if (claims && (await isPreviewVersionCurrent(env, spaceName, claims))) {
 			const response = await forwardToSpacePreview(request, env, spaceName);
 			if (isWebSocketResponse(response)) {
 				return response;

--- a/worker/api/routes/appRoutes.ts
+++ b/worker/api/routes/appRoutes.ts
@@ -71,6 +71,10 @@ export function setupAppRoutes(app: Hono<AppEnv>): void {
     
     // Generate git clone token for private repos - OWNER ONLY
     appRouter.post('/:id/git/token', setAuthLevel(AuthConfig.ownerOnly), adaptController(AppViewController, AppViewController.generateGitCloneToken));
+
+    // Generate owner-preview token so the owner can open a private deployed
+    // app's URL on a preview subdomain - OWNER ONLY
+    appRouter.post('/:id/preview-token', setAuthLevel(AuthConfig.ownerOnly), adaptController(AppViewController, AppViewController.generatePreviewToken));
     
     
     // Mount the app router under /api/apps

--- a/worker/api/routes/codegenRoutes.ts
+++ b/worker/api/routes/codegenRoutes.ts
@@ -30,6 +30,12 @@ export function setupCodegenRoutes(app: Hono<AppEnv>): void {
     // Only the app owner should be able to connect for editing purposes
     app.get('/api/agent/:agentId/connect', setAuthLevel(AuthConfig.ownerOnly), adaptController(CodingAgentController, CodingAgentController.connectToExistingAgent));
 
+    // Deploy an ephemeral SANDBOX preview. Intentionally `authenticated` (not
+    // `ownerOnly`): public-app previews must be viewer-triggerable, while
+    // private apps are owner-gated inside the controller. This is sandbox-only
+    // and never mutates production deploy state — see the rationale in
+    // CodingAgentController.deployPreview and the port-3000/token hardening in
+    // worker/services/sandbox/request-handler.ts.
     app.get('/api/agent/:agentId/preview', setAuthLevel(AuthConfig.authenticated), adaptController(CodingAgentController, CodingAgentController.deployPreview));
 
     // ========================================

--- a/worker/database/schema.ts
+++ b/worker/database/schema.ts
@@ -169,6 +169,11 @@ export const apps = sqliteTable('apps', {
     // Versioning (for future support)
     version: integer('version').default(1),
     parentAppId: text('parent_app_id'), // If forked from another app
+
+    // Preview-token revocation epoch. Incremented on every visibility change so
+    // outstanding space-preview tokens (which embed the value at mint) are
+    // rejected after a public->private toggle.
+    previewVersion: integer('preview_version').notNull().default(0),
     
     // Screenshot Information
     screenshotUrl: text('screenshot_url'), // URL to saved screenshot image

--- a/worker/database/services/AppService.ts
+++ b/worker/database/services/AppService.ts
@@ -524,11 +524,14 @@ export class AppService extends BaseService {
             return { success: false, error: 'You can only change visibility of your own apps' };
         }
 
-        // Update the app visibility
+        // Update the app visibility. Bump `previewVersion` on every visibility
+        // change so outstanding space-preview tokens (which embed the value at
+        // mint) are revoked immediately after a public->private toggle.
         const updatedApps = await this.database
             .update(schema.apps)
             .set({
                 visibility,
+                previewVersion: sql`${schema.apps.previewVersion} + 1`,
                 updatedAt: new Date()
             })
             .where(eq(schema.apps.id, appId))
@@ -573,6 +576,26 @@ export class AppService extends BaseService {
         }
 
         return row[0];
+    }
+
+    /**
+     * Read an app's current `previewVersion` from the PRIMARY DB (no cache) so a
+     * visibility toggle that bumped it is observed on the very next preview
+     * request (<1s revocation of outstanding space-preview tokens).
+     * Returns `null` if the app does not exist.
+     */
+    async getPreviewVersion(appId: string): Promise<number | null> {
+        const row = await this.database
+            .select({ previewVersion: schema.apps.previewVersion })
+            .from(schema.apps)
+            .where(eq(schema.apps.id, appId))
+            .limit(1);
+
+        if (row.length === 0) {
+            return null;
+        }
+
+        return row[0].previewVersion;
     }
 
     // ========================================

--- a/worker/database/services/AppService.ts
+++ b/worker/database/services/AppService.ts
@@ -546,6 +546,35 @@ export class AppService extends BaseService {
         return { success: true, app: updatedApps[0] };
     }
 
+    /**
+     * Resolve the owning app for a deployed worker by its deployment id
+     * (the subdomain used by the dispatch namespace equals `deploymentId`).
+     *
+     * Reads from the PRIMARY DB (not a read replica) with NO caching so that a
+     * just-toggled `visibility` is observed on the very next dispatch request
+     * (meets the <1s public->private revocation requirement). This is a single
+     * indexed lookup on `deployment_id`.
+     */
+    async getAppOwnershipByDeploymentId(
+        deploymentId: string
+    ): Promise<{ id: string; userId: string | null; visibility: 'private' | 'public' } | null> {
+        const row = await this.database
+            .select({
+                id: schema.apps.id,
+                userId: schema.apps.userId,
+                visibility: schema.apps.visibility,
+            })
+            .from(schema.apps)
+            .where(eq(schema.apps.deploymentId, deploymentId))
+            .limit(1);
+
+        if (row.length === 0) {
+            return null;
+        }
+
+        return row[0];
+    }
+
     // ========================================
     // APP VIEW CONTROLLER OPERATIONS
     // ========================================

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -15,6 +15,13 @@ import {
 	matchSpacePreviewParams,
 } from './api/handlers/space-preview';
 import { getAgentStub } from './agents';
+import { AppService } from './database/services/AppService';
+import {
+	buildOwnerPreviewCookie,
+	readOwnerPreviewCookie,
+	readOwnerPreviewTokenFromQuery,
+	verifyOwnerPreviewToken,
+} from './utils/ownerPreviewToken';
 
 // Durable Object and Service exports
 export { UserAppSandboxService } from './services/sandbox/sandboxSdkClient';
@@ -153,7 +160,45 @@ async function handleUserAppRequest(request: Request, env: Env): Promise<Respons
 	}
 
 	// Extract the app name (e.g., "xyz" from "xyz.build.cloudflare.dev").
+	// This subdomain equals the app's `deploymentId`.
 	const appName = subdomain;
+
+	// --- Visibility gate: private deployed apps are reachable by the owner only ---
+	// Consult the app's CURRENT visibility on every dispatch request (primary DB,
+	// no cache) so a public->private toggle takes effect within ~1s. Without this,
+	// toggling an app private still left the deployed worker URL publicly served.
+	const appService = new AppService(env);
+	const ownership = await appService.getAppOwnershipByDeploymentId(appName);
+	if (!ownership) {
+		// Fail closed: no owning app row for this deployment id.
+		logger.warn(`No app found for deployment '${appName}', refusing dispatch.`);
+		return new Response('This application is not currently available.', { status: 404 });
+	}
+
+	let ownerAuthedViaQuery = false;
+	if (ownership.visibility === 'private' && ownership.userId) {
+		// Owner access on preview subdomains: main-domain session cookies are not
+		// sent cross-subdomain, so accept a deployment-scoped owner-preview token
+		// (query param on first hit, then an HttpOnly subdomain cookie).
+		const queryToken = readOwnerPreviewTokenFromQuery(url);
+		const cookieToken = readOwnerPreviewCookie(request);
+
+		let ownerId: string | null = null;
+		if (queryToken) {
+			ownerId = await verifyOwnerPreviewToken(env, queryToken, appName);
+			if (ownerId) ownerAuthedViaQuery = true;
+		}
+		if (!ownerId && cookieToken) {
+			ownerId = await verifyOwnerPreviewToken(env, cookieToken, appName);
+		}
+
+		if (!ownerId || ownerId !== ownership.userId) {
+			// Indistinguishable from a non-existent app (do not confirm existence).
+			return new Response('This application is not currently available.', { status: 404 });
+		}
+	}
+	// public apps, anonymous apps (userId === null), and verified owners fall through.
+
 	const dispatcher = env['DISPATCHER'];
 
 	try {
@@ -167,6 +212,15 @@ async function handleUserAppRequest(request: Request, env: Env): Promise<Respons
         headers = setOriginControl(env, request, headers);
         headers.append('Vary', 'Origin');
 		headers.set('Access-Control-Expose-Headers', 'X-Preview-Type');
+
+		// Bootstrap the subdomain-scoped owner cookie so subsequent requests
+		// (iframe sub-resources, client fetches) don't need the query token.
+		if (ownerAuthedViaQuery) {
+			headers.append(
+				'Set-Cookie',
+				buildOwnerPreviewCookie({ token: readOwnerPreviewTokenFromQuery(url)!, secure: url.protocol === 'https:' }),
+			);
+		}
 
 		return new Response(dispatcherResponse.body, {
 			status: dispatcherResponse.status,

--- a/worker/services/rate-limit/config.ts
+++ b/worker/services/rate-limit/config.ts
@@ -53,6 +53,7 @@ export enum RateLimitType {
 	AUTH_RATE_LIMIT = 'authRateLimit',
 	APP_CREATION = 'appCreation',
 	LLM_CALLS = 'llmCalls',
+	SPACE_PREVIEW = 'spacePreview',
 }
 
 export interface RateLimitSettings {
@@ -60,6 +61,7 @@ export interface RateLimitSettings {
 	[RateLimitType.AUTH_RATE_LIMIT]: RLRateLimitConfig;
 	[RateLimitType.APP_CREATION]: DORateLimitConfig | KVRateLimitConfig;
 	[RateLimitType.LLM_CALLS]: LLMCallsRateLimitConfig;
+	[RateLimitType.SPACE_PREVIEW]: DORateLimitConfig | KVRateLimitConfig;
 }
 
 export const DEFAULT_RATE_LIMIT_SETTINGS: RateLimitSettings = {
@@ -89,5 +91,16 @@ export const DEFAULT_RATE_LIMIT_SETTINGS: RateLimitSettings = {
 		excludeBYOKUsers: true,
 		// Connected users still consume the free daily allotment first; only BYOK (actively-billing) users skip limits.
 		excludeCloudflareConnected: false,
+	},
+	// Per-preview-token limit for SpaceDO previews (dispatched outside the Hono
+	// chain, so the global API limiter does not apply). Generous enough for a
+	// legitimate page's asset sub-requests while capping sustained floods.
+	spacePreview: {
+		enabled: true,
+		store: RateLimitStore.DURABLE_OBJECT,
+		limit: 600,
+		period: 60, // 600 requests / minute per preview token
+		burst: 120,
+		burstWindow: 10,
 	},
 };

--- a/worker/services/rate-limit/rateLimits.ts
+++ b/worker/services/rate-limit/rateLimits.ts
@@ -147,6 +147,50 @@ export class RateLimitService {
         }
     }
 
+    /**
+     * Per-preview-token rate limit for SpaceDO previews. These are dispatched
+     * outside the Hono chain (via handleSpacePreview -> SpaceDO stub.fetch), so
+     * the global API limiter never runs. `tokenId` should be an opaque,
+     * non-reversible identifier for the preview token (e.g. a hash), never the
+     * raw token. Throws RateLimitExceededError when the limit is exceeded.
+     */
+    static async enforceSpacePreviewRateLimit(
+        env: Env,
+        config: RateLimitSettings,
+        tokenId: string,
+        request: Request
+    ): Promise<void> {
+        if (!config[RateLimitType.SPACE_PREVIEW].enabled) {
+            return;
+        }
+        const identifier = `preview:${tokenId}`;
+        const key = this.buildRateLimitKey(RateLimitType.SPACE_PREVIEW, identifier);
+
+        try {
+            const result = await this.enforce(env, key, config, RateLimitType.SPACE_PREVIEW);
+            if (!result.success) {
+                this.logger.warn('Space preview rate limit exceeded', {
+                    key,
+                    userAgent: request.headers.get('User-Agent'),
+                    ip: request.headers.get('CF-Connecting-IP'),
+                });
+                captureSecurityEvent('rate_limit_exceeded', {
+                    limitType: RateLimitType.SPACE_PREVIEW,
+                    identifier,
+                    key,
+                    userAgent: request.headers.get('User-Agent') || undefined,
+                    ip: request.headers.get('CF-Connecting-IP') || undefined,
+                });
+                throw new RateLimitExceededError(`Space preview rate limit exceeded`, RateLimitType.SPACE_PREVIEW);
+            }
+        } catch (error) {
+            if (error instanceof RateLimitExceededError || error instanceof SecurityError) {
+                throw error;
+            }
+            this.logger.error('Failed to enforce space preview rate limit', error);
+        }
+    }
+
     static async enforceAuthRateLimit(
         env: Env,
         config: RateLimitSettings,

--- a/worker/services/sandbox/request-handler.test.ts
+++ b/worker/services/sandbox/request-handler.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const validatePortToken = vi.fn();
+const containerFetch = vi.fn();
+const sandboxFetch = vi.fn();
+
+vi.mock('@cloudflare/sandbox', () => ({
+	getSandbox: () => ({
+		validatePortToken,
+		containerFetch,
+		fetch: sandboxFetch,
+	}),
+	Sandbox: class {},
+}));
+
+// Imported after the mock so the module under test picks up the mocked getSandbox.
+const { proxyToSandbox } = await import('./request-handler');
+
+const env = { Sandbox: {} } as unknown as Parameters<typeof proxyToSandbox>[1];
+
+function req(hostname: string, init?: RequestInit): Request {
+	return new Request(`https://${hostname}/`, init);
+}
+
+// port-sandboxId-token.domain — token is exactly 16 chars.
+const TOKEN = 'abcdef0123456789';
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('proxyToSandbox', () => {
+	it('returns null for a hostname that is not a sandbox route', async () => {
+		const res = await proxyToSandbox(req('example.com'), env);
+		expect(res).toBeNull();
+		expect(validatePortToken).not.toHaveBeenCalled();
+	});
+
+	it('proxies through when the port token is valid', async () => {
+		validatePortToken.mockResolvedValue(true);
+		containerFetch.mockResolvedValue(new Response('ok'));
+
+		const res = await proxyToSandbox(req(`8001-mysandbox-${TOKEN}.preview.example.dev`), env);
+
+		expect(validatePortToken).toHaveBeenCalledWith(8001, TOKEN);
+		expect(containerFetch).toHaveBeenCalledTimes(1);
+		expect(res?.status).toBe(200);
+	});
+
+	it('returns 404 for a syntactically valid but unissued token (never reaches container)', async () => {
+		validatePortToken.mockResolvedValue(false);
+
+		const res = await proxyToSandbox(req(`8001-mysandbox-${TOKEN}.preview.example.dev`), env);
+
+		expect(res?.status).toBe(404);
+		expect(containerFetch).not.toHaveBeenCalled();
+		expect(sandboxFetch).not.toHaveBeenCalled();
+	});
+
+	it('blocks control-plane port 3000 with 404 even with a token, before any token check', async () => {
+		const res = await proxyToSandbox(req(`3000-mysandbox-${TOKEN}.preview.example.dev`), env);
+
+		expect(res?.status).toBe(404);
+		expect(validatePortToken).not.toHaveBeenCalled();
+		expect(containerFetch).not.toHaveBeenCalled();
+	});
+
+	it('rejects a WebSocket upgrade with a bad token (no sandbox.fetch)', async () => {
+		validatePortToken.mockResolvedValue(false);
+
+		const res = await proxyToSandbox(
+			req(`8001-mysandbox-${TOKEN}.preview.example.dev`, {
+				headers: { Upgrade: 'websocket' },
+			}),
+			env,
+		);
+
+		expect(res?.status).toBe(404);
+		expect(sandboxFetch).not.toHaveBeenCalled();
+	});
+});

--- a/worker/services/sandbox/request-handler.ts
+++ b/worker/services/sandbox/request-handler.ts
@@ -22,6 +22,14 @@ export interface RouteInfo {
   token: string;
 }
 
+/**
+ * Control-plane / internal ports that must never be reachable through a public
+ * preview subdomain. The user-app dev server runs on other ports; the sandbox
+ * management API (file read/exec) lives on 3000 and is only meant to be reached
+ * internally via DO RPC / containerFetch, never from the public host.
+ */
+const CONTROL_PLANE_PORTS = new Set<number>([3000, 8787]);
+
 export async function proxyToSandbox<E extends SandboxEnv>(
   request: Request,
   env: E
@@ -34,31 +42,39 @@ export async function proxyToSandbox<E extends SandboxEnv>(
       return null; // Not a request to an exposed container port
     }
 
-    const { sandboxId, port, path, token } = routeInfo;
+    const { sandboxId, port, path } = routeInfo;
+    // NOTE: id-resolution must match how the sandbox was created
+    // (`getSandbox(env.Sandbox, sandboxId)` with no options in
+    // sandboxSdkClient.ts). Do NOT add `{ normalizeId: true }` here or
+    // `validatePortToken` would hit a different DO instance with no stored
+    // tokens and reject every legitimate preview.
     const sandbox = getSandbox(env.Sandbox, sandboxId);
 
-    logger.info("[Proxy] Sandbox", sandbox, "Port", port, "Path", path, "Token", token);
+    // Never expose the control plane / reserved ports through public routing.
+    if (CONTROL_PLANE_PORTS.has(port)) {
+      logger.warn('Blocked control-plane port access', { sandboxId, port, path });
+      return new Response('Not found', { status: 404 });
+    }
+
+    // Verify the per-port token against the token stored in the Sandbox DO by
+    // `exposePort()`. Anyone who merely knows a (sandboxId, port) pair but not
+    // the issued token gets a 404 (indistinguishable from a missing sandbox).
+    if (!(await sandbox.validatePortToken(port, routeInfo.token))) {
+      logger.warn('Blocked invalid sandbox port token', { sandboxId, port, path });
+      return new Response('Not found', { status: 404 });
+    }
 
     // Detect WebSocket upgrade request
     const upgradeHeader = request.headers.get('Upgrade');
     if (upgradeHeader?.toLowerCase() === 'websocket') {
-      logger.info("[Proxy] WebSocket upgrade request", upgradeHeader, "Port", port, "Path", path, "Token", token);
+      logger.info('[Proxy] WebSocket upgrade request', { sandboxId, port, path });
       // WebSocket path: Must use fetch() not containerFetch()
       // This bypasses JSRPC serialization boundary which cannot handle WebSocket upgrades
       return await sandbox.fetch(switchPort(request, port));
     }
 
-    // Build proxy request with proper headers
-    let proxyUrl: string;
-
-    // Route based on the target port
-    if (port !== 3000) {
-      // Route directly to user's service on the specified port
-      proxyUrl = `http://localhost:${port}${path}${url.search}`;
-    } else {
-      // Port 3000 is our control plane - route normally
-      proxyUrl = `http://localhost:3000${path}${url.search}`;
-    }
+    // Route directly to user's service on the specified port
+    const proxyUrl = `http://localhost:${port}${path}${url.search}`;
 
     const proxyRequest = new Request(proxyUrl, {
       method: request.method,
@@ -78,7 +94,6 @@ export async function proxyToSandbox<E extends SandboxEnv>(
       sandboxId,
       port,
       path,
-      token,
       proxyUrl,
     });
 
@@ -108,6 +123,13 @@ function extractSandboxRoute(url: URL): RouteInfo | null {
   const token = subdomainMatch[3]; // Mandatory token
 
   const port = parseInt(portStr, 10);
+
+  // Reject malformed / out-of-range ports at parse time (mirrors the SDK's
+  // validatePort range check). Reserved control-plane ports (3000/8787) are
+  // still parsed here so proxyToSandbox can return an explicit 404 for them.
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    return null;
+  }
 
   // DNS subdomain length limit is 63 characters
   if (sandboxId.length > 63) {

--- a/worker/utils/ownerPreviewToken.ts
+++ b/worker/utils/ownerPreviewToken.ts
@@ -1,0 +1,97 @@
+/**
+ * Owner-preview token — lets the authenticated owner of a PRIVATE deployed app
+ * open its deployment URL on a preview subdomain.
+ *
+ * Main-domain session cookies are host-scoped to `CUSTOM_DOMAIN` and are NOT
+ * sent to preview subdomains, so the routing gate cannot see the normal session
+ * there. Instead the UI mints this short-lived, deployment-scoped token and
+ * appends it to the deployment URL; on first hit the gate sets an HttpOnly,
+ * subdomain-scoped cookie so subsequent requests need no query param.
+ */
+import { JWTUtils } from './jwtUtils';
+
+const OWNER_PREVIEW_PURPOSE = 'owner_preview';
+export const OWNER_PREVIEW_TOKEN_TTL_SECONDS = 60 * 60; // 1 hour
+export const OWNER_PREVIEW_QUERY_PARAM = '__vibesdk_owner';
+export const OWNER_PREVIEW_COOKIE_NAME = '__vibesdk_owner';
+
+export interface OwnerPreviewClaims {
+	/** The app owner's user id. */
+	userId: string;
+	/** The deployment id (== preview subdomain) this token is scoped to. */
+	deploymentId: string;
+}
+
+export async function signOwnerPreviewToken(
+	env: { JWT_SECRET: string },
+	claims: OwnerPreviewClaims,
+): Promise<string> {
+	const jwt = JWTUtils.getInstance(env);
+	return jwt.signPayload(
+		{ ...claims, purpose: OWNER_PREVIEW_PURPOSE },
+		OWNER_PREVIEW_TOKEN_TTL_SECONDS,
+	);
+}
+
+/**
+ * Verify a token and confirm it was minted for `expectedDeploymentId`.
+ * Returns the owner user id on success, or `null` otherwise.
+ */
+export async function verifyOwnerPreviewToken(
+	env: { JWT_SECRET: string },
+	token: string,
+	expectedDeploymentId: string,
+): Promise<string | null> {
+	const jwt = JWTUtils.getInstance(env);
+	const payload = await jwt.verifyPayload(token);
+	if (!payload) return null;
+	if (payload.purpose !== OWNER_PREVIEW_PURPOSE) return null;
+	if (typeof payload.deploymentId !== 'string' || payload.deploymentId !== expectedDeploymentId) {
+		return null;
+	}
+	if (typeof payload.userId !== 'string' || payload.userId.trim() === '') return null;
+	return payload.userId;
+}
+
+/** Read the owner-preview token from the `?__vibesdk_owner=` query param. */
+export function readOwnerPreviewTokenFromQuery(url: URL): string | null {
+	const token = url.searchParams.get(OWNER_PREVIEW_QUERY_PARAM);
+	return token && token.trim() !== '' ? token : null;
+}
+
+/** Read the owner-preview cookie value from a request's `Cookie` header. */
+export function readOwnerPreviewCookie(request: Request): string | null {
+	const header = request.headers.get('Cookie');
+	if (!header) return null;
+	for (const pair of header.split(';')) {
+		const idx = pair.indexOf('=');
+		if (idx === -1) continue;
+		const name = pair.slice(0, idx).trim();
+		if (name === OWNER_PREVIEW_COOKIE_NAME) {
+			return pair.slice(idx + 1).trim();
+		}
+	}
+	return null;
+}
+
+/**
+ * Build the `Set-Cookie` value for the HttpOnly owner-preview cookie. It is
+ * scoped to the exact preview subdomain (no `Domain` attribute) and `Path=/`.
+ */
+export function buildOwnerPreviewCookie(opts: {
+	token: string;
+	secure: boolean;
+	ttlSeconds?: number;
+}): string {
+	const { token, secure } = opts;
+	const maxAge = opts.ttlSeconds ?? OWNER_PREVIEW_TOKEN_TTL_SECONDS;
+	const parts = [
+		`${OWNER_PREVIEW_COOKIE_NAME}=${token}`,
+		'Path=/',
+		`Max-Age=${maxAge}`,
+		'HttpOnly',
+		'SameSite=Lax',
+	];
+	if (secure) parts.push('Secure');
+	return parts.join('; ');
+}

--- a/worker/utils/spacePreviewToken.test.ts
+++ b/worker/utils/spacePreviewToken.test.ts
@@ -18,6 +18,7 @@ describe('spacePreviewToken', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 3,
 		});
 
 		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'main');
@@ -25,7 +26,24 @@ describe('spacePreviewToken', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 3,
 		});
+	});
+
+	it('rejects a token missing previewVersion', async () => {
+		const jwt = JWTUtils.getInstance(testEnv);
+		const token = await jwt.signPayload(
+			{
+				spaceName: 'space-a',
+				branch: 'main',
+				userId: 'user-a',
+				purpose: 'space_preview',
+			},
+			60,
+		);
+
+		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'main');
+		expect(claims).toBeNull();
 	});
 
 	it('rejects token for a different space', async () => {
@@ -33,6 +51,7 @@ describe('spacePreviewToken', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 
 		const claims = await verifySpacePreviewToken(testEnv, token, 'space-b', 'main');
@@ -44,6 +63,7 @@ describe('spacePreviewToken', () => {
 			spaceName: 'space-a',
 			branch: 'main',
 			userId: 'user-a',
+			previewVersion: 0,
 		});
 
 		const claims = await verifySpacePreviewToken(testEnv, token, 'space-a', 'feature');

--- a/worker/utils/spacePreviewToken.ts
+++ b/worker/utils/spacePreviewToken.ts
@@ -8,6 +8,12 @@ export interface SpacePreviewClaims {
 	spaceName: string;
 	branch: string;
 	userId: string;
+	/**
+	 * The app's `previewVersion` at mint time. Compared against the app's
+	 * current value at preview time so a visibility toggle (which bumps the
+	 * version) revokes this token.
+	 */
+	previewVersion: number;
 }
 
 export async function signSpacePreviewToken(
@@ -31,11 +37,13 @@ export async function verifySpacePreviewToken(
 	if (typeof payload.spaceName !== 'string' || payload.spaceName !== expectedSpaceName) return null;
 	if (typeof payload.branch !== 'string' || payload.branch !== expectedBranch) return null;
 	if (typeof payload.userId !== 'string' || payload.userId.trim() === '') return null;
+	if (typeof payload.previewVersion !== 'number' || !Number.isFinite(payload.previewVersion)) return null;
 
 	return {
 		spaceName: payload.spaceName,
 		branch: payload.branch,
 		userId: payload.userId,
+		previewVersion: payload.previewVersion,
 	};
 }
 


### PR DESCRIPTION
## Summary

Closes several access-control and abuse gaps in the app/space preview paths. Private apps were reachable regardless of ownership, sandbox container ports could be proxied without a valid per-port token, space-preview tokens survived a public→private toggle, and space previews had no rate limit while rebuilding the asset manifest on every request.

This PR is structured as 5 focused commits.

## Changes

### 1. Enforce app visibility at the dispatch layer
- The dispatcher served apps regardless of visibility. Now dispatch is gated: **private apps are owner-only** (404 otherwise); public/anonymous access is unchanged.
- Added an uncached, primary-DB ownership lookup by deployment.
- New deployment-scoped **owner preview token** plus an owner-only endpoint to mint it.
- Frontend: a client method + type for minting the token, and owner-preview URL wiring for private apps in the app view and deployment controls.

### 2. Verify per-port token before sandbox preview access
- Block **control-plane ports (3000/8787)** with 404.
- Require token validation **before any container access**, including the WebSocket upgrade path (previously bypassable).
- Restore port-range validation and stop logging the raw token.
- Adds coverage for the proxy handler.

### 3. Document the authenticated preview endpoint as intentional (docs-only)
- Clarifies that the agent preview endpoint is authenticated (not owner-only) by design — public-app previews are viewer-triggerable and sandbox-only, never mutating production deploy state. No behavior change.

### 4. Revoke space-preview tokens on visibility change
- Adds a `preview_version` epoch column (**migration `0006`**), bumped on every visibility change.
- Tokens embed the epoch at mint; the space-preview handler rejects tokens whose epoch is stale, so links minted while public stop working within ~1s of a public→private toggle.
- The epoch is read uncached from the primary DB.

### 5. Rate-limit space previews + cache the asset manifest
- Space previews are dispatched outside the Hono chain, so the global API limiter never applied. Adds a dedicated limiter enforced **per hashed token** → `429` on exceed.
- The space preview now caches the built asset manifest/storage per `branch:commitHash` with an LRU + TTL bound (previously rebuilt every request).
- Adds handler rate-limit tests.

## Security impact
- Prevents unauthorized viewing of private apps via the dispatcher.
- Closes a sandbox credential-theft path (control-plane access / unissued-token proxying).
- Ensures preview links are promptly revoked on privacy changes.
- Bounds preview resource amplification under load.