### PR TITLE
fix: refresh Cloudflare AI Gateway list without reconnecting (#398)

### DIFF
--- a/src/components/cloudflare-account-selector.tsx
+++ b/src/components/cloudflare-account-selector.tsx
@@ -13,7 +13,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { toast } from 'sonner';
 import { apiClient } from '@/lib/api-client';
 import CloudflareLogo from '@/assets/provider-logos/cloudflare.svg?react';
-import { Loader2, CheckCircle2, AlertCircle, MoreVertical, ExternalLink, LogOut } from 'lucide-react';
+import { Loader2, CheckCircle2, AlertCircle, MoreVertical, ExternalLink, LogOut, RefreshCw } from 'lucide-react';
 import { useLimitsContext } from '@/contexts/limits-context';
 
 interface CloudflareAccount {
@@ -47,6 +47,7 @@ export function CloudflareAccountSelector() {
 	const [accounts, setAccounts] = useState<CloudflareAccount[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
+	const [refreshing, setRefreshing] = useState(false);
 	const [selectedAccountId, setSelectedAccountId] = useState<string>('');
 	const [selectedGatewayId, setSelectedGatewayId] = useState<string>('');
 	const [availableGateways, setAvailableGateways] = useState<Gateway[]>([]);
@@ -90,12 +91,19 @@ export function CloudflareAccountSelector() {
 		fetchAccounts();
 	}, []);
 
-	const fetchAccounts = async () => {
+	const fetchAccounts = async ({ refresh = false }: { refresh?: boolean } = {}) => {
 		try {
-			setLoading(true);
-			const response = await fetch('/api/cloudflare/accounts', {
-				credentials: 'include',
-			});
+			if (refresh) {
+				setRefreshing(true);
+			} else {
+				setLoading(true);
+			}
+			const response = await fetch(
+				`/api/cloudflare/accounts${refresh ? '?refresh=true' : ''}`,
+				{
+					credentials: 'include',
+				},
+			);
 
 			if (!response.ok) {
 				throw new Error('Failed to fetch accounts');
@@ -138,7 +146,13 @@ export function CloudflareAccountSelector() {
 			toast.error('Failed to load Cloudflare accounts');
 		} finally {
 			setLoading(false);
+			setRefreshing(false);
 		}
+	};
+
+	const handleRefresh = async () => {
+		await fetchAccounts({ refresh: true });
+		toast.success('Refreshed Cloudflare accounts and gateways');
 	};
 
 	// Update available gateways when account changes
@@ -267,6 +281,18 @@ export function CloudflareAccountSelector() {
 								<AlertCircle className="w-3.5 h-3.5 text-amber-500" />
 								<span className="text-amber-600 dark:text-amber-400">Not connected</span>
 							</div>
+						)}
+						{isConnected && (
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-7 w-7"
+								onClick={handleRefresh}
+								disabled={refreshing}
+								title="Refresh accounts and gateways"
+							>
+								<RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+							</Button>
 						)}
 						{isConnected && (
 							<DropdownMenu>

--- a/worker/api/controllers/cloudflareAccount/controller.ts
+++ b/worker/api/controllers/cloudflareAccount/controller.ts
@@ -6,19 +6,26 @@
 import { BaseController } from '../baseController';
 import { RouteContext } from '../../types/route-context';
 import { CloudflareAccountService } from '../../../services/cloudflare/CloudflareAccountService';
+import { CloudflareProvisioningService } from '../../../services/cloudflare/CloudflareProvisioningService';
 import { UserService } from '../../../database/services/UserService';
 import { createLogger } from '../../../logger';
 import { buildClearTokenCookie } from '../../../utils/oauthCookie';
+import { resolveCloudflareAccessTokenFromRequest } from '../../../services/rate-limit/usageChecker';
 
 export class CloudflareAccountController extends BaseController {
 	static logger = createLogger('CloudflareAccountController');
 
 	/**
 	 * GET /api/cloudflare/accounts
-	 * Get all user's Cloudflare accounts with their gateways
+	 * Get all user's Cloudflare accounts with their gateways.
+	 *
+	 * When called with `?refresh=true`, re-fetches accounts/gateways from the
+	 * Cloudflare API (using the stored OAuth token) and persists them before
+	 * returning, so gateways created on Cloudflare after the initial connect
+	 * show up without needing to disconnect/reconnect.
 	 */
 	static async getAccounts(
-		_request: Request,
+		request: Request,
 		env: Env,
 		_ctx: ExecutionContext,
 		context: RouteContext,
@@ -32,10 +39,31 @@ export class CloudflareAccountController extends BaseController {
 		}
 
 		try {
+			const shouldRefresh = new URL(request.url).searchParams.get('refresh') === 'true';
+			let refreshedCookie: string | undefined;
+
+			if (shouldRefresh) {
+				const { accessToken, refreshedCookie: cookie } =
+					await resolveCloudflareAccessTokenFromRequest(env, user.id, request);
+				refreshedCookie = cookie;
+
+				if (accessToken) {
+					// Re-provision from Cloudflare. This adds newly-created gateways and
+					// updates metadata without touching the user's active selection when
+					// they already have gateways.
+					const provisioning = new CloudflareProvisioningService(env);
+					await provisioning.provisionFromToken(accessToken, user.id);
+				}
+			}
+
 			const accountService = new CloudflareAccountService(env);
 			const accounts = await accountService.getUserAccountsWithGateways(user.id);
 
-			return CloudflareAccountController.createSuccessResponse(accounts);
+			const response = CloudflareAccountController.createSuccessResponse(accounts);
+			if (refreshedCookie) {
+				response.headers.append('Set-Cookie', refreshedCookie);
+			}
+			return response;
 		} catch (error) {
 			this.logger.error('Error getting user accounts', error);
 			return CloudflareAccountController.createErrorResponse(

--- a/worker/services/rate-limit/usageChecker.ts
+++ b/worker/services/rate-limit/usageChecker.ts
@@ -186,6 +186,46 @@ export async function checkUsageAndBalance(
 }
 
 /**
+ * Resolve a usable Cloudflare access token from the request's HttpOnly cookie.
+ *
+ * Reuses the same decrypt/validate/refresh path as usage checking so callers
+ * (e.g. refreshing the account/gateway list on demand) get a live token without
+ * duplicating that logic. Returns a `refreshedCookie` the caller MUST echo as a
+ * `Set-Cookie` header when the token was transparently refreshed or when a bad
+ * cookie should be cleared.
+ */
+export async function resolveCloudflareAccessTokenFromRequest(
+	env: Env,
+	userId: string,
+	request: Request,
+): Promise<{ accessToken: string | null; refreshedCookie?: string }> {
+	if (!isCloudflareGatewayLimitsEnabled(env)) {
+		return { accessToken: null };
+	}
+
+	const blob = extractCloudflareToken(request, env);
+	if (!blob) {
+		return { accessToken: null };
+	}
+
+	const resolved = await resolveAccessToken(env, userId, blob, request);
+	if (resolved.accessToken) {
+		return {
+			accessToken: resolved.accessToken,
+			refreshedCookie: resolved.refreshedBlob
+				? buildTokenCookie(env, resolved.refreshedBlob)
+				: undefined,
+		};
+	}
+
+	if (resolved.clearCookie) {
+		return { accessToken: null, refreshedCookie: buildClearTokenCookie(env) };
+	}
+
+	return { accessToken: null };
+}
+
+/**
  * Decrypt the stored blob, validate user binding, and refresh the access token
  * if it is past the refresh threshold. Returns the usable access token plus an
  * optional new encrypted blob when refresh happened. `clearCookie: true` signals


### PR DESCRIPTION
## Problem

Fixes #398.

After connecting a Cloudflare account, creating a **new AI Gateway** on Cloudflare never showed up in the Settings gateway dropdown. Refreshing the page or re-selecting the account didn't help — the only workaround was disconnecting and reconnecting the account.

### Root cause

`GET /api/cloudflare/accounts` (`CloudflareAccountController.getAccounts`) only ever reads persisted `cloudflareAccounts`/`aiGateways` rows from the database. Those rows are populated exclusively by `CloudflareProvisioningService.provisionFromToken`, which runs on connect/reconnect. There was no code path to re-fetch gateways from the Cloudflare API for an already-connected account, so newly created gateways stayed invisible.

## Fix

- **Backend:** `GET /api/cloudflare/accounts?refresh=true` now re-provisions from the Cloudflare API (using the stored HttpOnly OAuth token) before returning the list. Because the user already has gateways, re-provisioning adds/updates gateway metadata **without changing their active selection**. Any transparently-refreshed OAuth cookie is echoed back via `Set-Cookie`.
- Added an exported helper `resolveCloudflareAccessTokenFromRequest` in `usageChecker.ts` that reuses the existing decrypt/validate/refresh logic, so the controller doesn't duplicate token handling.
- **Frontend:** Added a refresh button to the Cloudflare AI Gateway settings card that calls the refresh endpoint and reloads the account/gateway list.

## Testing

- `npm run typecheck` — passes
- `npm run lint` — passes
- Existing unit tests pass (pre-commit hook)

Manual: connect a Cloudflare account, create a new gateway on Cloudflare, click refresh in Settings — the new gateway now appears without disconnecting/reconnecting.
