### PR TITLE
fix: show 24 recent public apps on homepage

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    
+
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
@@ -29,9 +29,9 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    
+
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Size & Type Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -102,9 +102,9 @@ export default function Home() {
 		loading,
 	} = usePaginatedApps({
 		type: 'public',
-		defaultSort: 'popular',
+		defaultSort: 'recent',
 		defaultPeriod: 'week',
-		limit: 6,
+		limit: 24,
 	});
 
 	// Discover section should appear only when enough apps are available and loading is done


### PR DESCRIPTION
In homepage, show the recent 24 public apps instead of the popular ones.