### PR TITLE
UI revamp: LinkProvider, chat app actions, and settings polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { FeatureProvider } from './features';
 import { Toasty } from '@cloudflare/kumo';
 import { queryClient } from './lib/query-client';
 import { useAppsQuerySync } from './hooks/use-apps';
+import { AppLinkProvider } from './components/providers/app-link-provider';
 
 function AppsQuerySync() {
 	useAppsQuerySync();
@@ -31,7 +32,9 @@ export default function App() {
 									<AuthModalProvider>
 										<AppLayout>
 											<Toasty>
-												<Outlet />
+												<AppLinkProvider>
+													<Outlet />
+												</AppLinkProvider>
 											</Toasty>
 										</AppLayout>
 										<Toaster

--- a/src/components/cloudflare-account-selector.tsx
+++ b/src/components/cloudflare-account-selector.tsx
@@ -178,7 +178,7 @@ export function CloudflareAccountSelector() {
 		try {
 			setSaving(true);
 			const response = await apiClient.setCloudflareSelection(selectedAccountId, selectedGatewayId);
-			
+
 			if (response.success) {
 				toast.success('Cloudflare configuration saved successfully');
 				// Refresh the page to update the badge
@@ -211,7 +211,7 @@ export function CloudflareAccountSelector() {
 	};
 
 	const cardHeader = (
-		<div className="flex items-center gap-2">
+		<div className="flex items-center gap-2 font-funky-mono tracking-tighter">
 			<span className="h-lh flex items-center">
 				<CloudflareLogo className="size-4" />
 			</span>

--- a/src/components/providers/app-link-provider.tsx
+++ b/src/components/providers/app-link-provider.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import { LinkProvider, type LinkComponentProps } from '@cloudflare/kumo';
+
+const AppLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(
+	function AppLink({ href, to, ...rest }, ref) {
+		const destination = href ?? to;
+		const isExternal =
+			destination?.startsWith('http') &&
+			new URL(destination).origin !== window.location.origin;
+
+		if (isExternal) {
+			return <a ref={ref} href={destination} {...rest} />;
+		}
+
+		return <Link ref={ref} to={destination ?? ''} {...rest} />;
+	},
+);
+
+export function AppLinkProvider({ children }: { children: ReactNode }) {
+	return <LinkProvider component={AppLink}>{children}</LinkProvider>;
+}

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -15,8 +15,20 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
 import { LoaderCircle, MoreHorizontal, RotateCcw } from 'lucide-react';
-import { GlobeHemisphereWestIcon, LockKey } from '@phosphor-icons/react';
-import { Button, DropdownMenu } from '@cloudflare/kumo';
+import {
+	BookmarkSimpleIcon,
+	DotsThree,
+	GitBranch,
+	Globe,
+	Lock,
+	LockOpen,
+} from '@phosphor-icons/react';
+import {
+	Badge,
+	Button,
+	DropdownMenu,
+	useKumoToastManager,
+} from '@cloudflare/kumo';
 import clsx from 'clsx';
 import { UserMessage, AIMessage } from './components/messages';
 import { PhaseTimeline } from './components/phase-timeline';
@@ -38,7 +50,11 @@ import type { ChatMessage } from './utils/message-helpers';
 import { featureRegistry } from '@/features';
 import { useFileContentStream } from './hooks/use-file-content-stream';
 import { logger } from '@/utils/logger';
-import { useApp } from '@/hooks/use-app';
+import {
+	useApp,
+	useToggleAppFavorite,
+	useUpdateAppVisibility,
+} from '@/hooks/use-app';
 import { useAuth } from '@/contexts/auth-context';
 import { useGitHubExport } from '@/hooks/use-github-export';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
@@ -49,7 +65,6 @@ import {
 	RollbackContext,
 	type RollbackHandler,
 } from './contexts/rollback-context';
-import { toast } from 'sonner';
 import {
 	detectContentType,
 	isDocumentationPath,
@@ -68,6 +83,8 @@ import {
 	getBackendLimitDialog,
 } from '@/utils/usage-limit-checker';
 import { queryKeys } from '@/lib/query-keys';
+import { ApiError } from '@/lib/api-client';
+import { capitalizeFirstLetter } from '@/lib/utils';
 
 const isPhasicBlueprint = (
 	blueprint?: BlueprintType | null,
@@ -125,12 +142,17 @@ export default function Chat() {
 
 	// Load existing app data if chatId is provided
 	const { app, loading: appLoading, refetch: refetchApp } = useApp(urlChatId);
+	const { mutateAsync: updateVisibility, isPending: isUpdatingVisibility } =
+		useUpdateAppVisibility(app?.id);
+	const { mutateAsync: toggleFavorite } = useToggleAppFavorite(app?.id);
+	const toast = useKumoToastManager();
 
 	// If we have an existing app, use its data
 	const displayQuery = app
 		? app.originalPrompt || app.title
 		: userQuery || '';
 	const appTitle = app?.title;
+	const isFavorited = app?.userFavorited || false;
 
 	// Manual refresh trigger for preview
 	const [manualRefreshTrigger, setManualRefreshTrigger] = useState(0);
@@ -239,6 +261,61 @@ export default function Chat() {
 	const githubExport = useGitHubExport(websocket, urlChatId, refetchApp);
 	const { user } = useAuth();
 	const queryClient = useQueryClient();
+	const isOwner = !!app && app.userId === user?.id;
+
+	const handleToggleVisibility = useCallback(async () => {
+		if (!app || !user || !isOwner) {
+			toast.add({
+				title: 'You can only change visibility of your own apps',
+				variant: 'error',
+			});
+			return;
+		}
+
+		try {
+			const newVisibility =
+				app.visibility === 'private' ? 'public' : 'private';
+			const result = await updateVisibility(newVisibility);
+
+			toast.add({
+				title:
+					result.message ||
+					`App is now ${newVisibility === 'private' ? 'private' : 'public'}`,
+				variant: 'success',
+			});
+		} catch (error) {
+			console.error('Error updating app visibility:', error);
+			toast.add({
+				title:
+					error instanceof ApiError
+						? error.message
+						: 'Failed to update visibility',
+				variant: 'error',
+			});
+		}
+	}, [app, user, isOwner, updateVisibility, toast]);
+
+	const handleFavorite = useCallback(async () => {
+		if (!app) return;
+		try {
+			const newState = await toggleFavorite();
+			toast.add({
+				title: newState
+					? 'Added to bookmarks'
+					: 'Removed from bookmarks',
+				variant: 'success',
+			});
+		} catch (error) {
+			console.error('Favorite error:', error);
+			toast.add({
+				title:
+					error instanceof ApiError
+						? error.message
+						: 'Failed to update bookmarks',
+				variant: 'error',
+			});
+		}
+	}, [app, toggleFavorite, toast]);
 
 	const navigate = useNavigate();
 
@@ -456,17 +533,21 @@ export default function Chat() {
 		return (commitHash: string) => {
 			if (!websocket) return;
 			if (isGenerating || isDeploying) {
-				toast.error(
-					'Please wait for the current action to finish before rolling back.',
-				);
+				toast.add({
+					title: 'Please wait for the current action to finish before rolling back.',
+					type: 'error',
+				});
 				return;
 			}
 			sendWebSocketMessage(websocket, 'rollback_to_commit', {
 				commitHash,
 			});
-			toast.info('Rolling back and redeploying…');
+			toast.add({
+				title: 'Rolling back and redeploying…',
+				type: 'info',
+			});
 		};
-	}, [behaviorType, websocket, isGenerating, isDeploying]);
+	}, [behaviorType, websocket, isGenerating, isDeploying, toast]);
 
 	// // Terminal functions
 	// const handleTerminalCommand = useCallback((command: string) => {
@@ -888,38 +969,118 @@ export default function Chat() {
 		<RollbackContext.Provider value={rollbackHandler}>
 			<div className="size-full flex flex-col min-h-0 text-text-primary">
 				{(blueprint?.title || appTitle || chatId || appLoading) && (
-					<div className="h-12 shrink-0 flex items-center px-4 border-b">
+					<div className="h-12 shrink-0 flex items-center gap-3 px-4 border-b">
 						{appLoading ? (
 							<div className="flex items-center gap-2 text-kumo-subtle text-sm">
 								<LoaderCircle className="size-4 animate-spin" />
 								Loading app...
 							</div>
 						) : (
-							<div className="flex min-w-0 flex-1 items-center max-w-md gap-2">
-								{app?.visibility === 'private' ? (
-									<LockKey
-										className="size-4 shrink-0 text-kumo-subtle"
-										weight="duotone"
-										aria-label="Private"
-									/>
-								) : (
-									<GlobeHemisphereWestIcon
-										className="size-4 shrink-0 text-kumo-subtle"
-										weight="duotone"
-										aria-label="Public"
-									/>
-								)}
-								<div
-									className="text-sm font-semibold truncate min-w-0"
-									title={
-										blueprint?.title ||
-										appTitle ||
-										undefined
-									}
-								>
-									{blueprint?.title || appTitle}
+							<>
+								<div className="min-w-0 flex-1 flex items-center gap-2">
+									<div
+										className="text-sm font-semibold truncate min-w-0"
+										title={
+											blueprint?.title ||
+											appTitle ||
+											undefined
+										}
+									>
+										{blueprint?.title || appTitle}
+									</div>
+									{app?.visibility && (
+										<Badge
+											className="shrink-0"
+											variant={
+												app.visibility === 'private'
+													? 'secondary'
+													: 'success'
+											}
+										>
+											<span className="inline-flex items-center gap-1">
+												<Globe
+													className="h-3 w-3"
+													weight="duotone"
+												/>
+												{capitalizeFirstLetter(
+													app.visibility,
+												)}
+											</span>
+										</Badge>
+									)}
 								</div>
-							</div>
+								<div className="flex items-center gap-1.5 shrink-0">
+									{isOwner && app && (
+										<Button
+											variant={
+												app.visibility === 'private'
+													? 'primary'
+													: 'secondary'
+											}
+											size="sm"
+											onClick={handleToggleVisibility}
+											disabled={isUpdatingVisibility}
+											loading={isUpdatingVisibility}
+											icon={
+												app.visibility === 'private' ? (
+													<LockOpen
+														className="size-3.5"
+														weight="duotone"
+													/>
+												) : (
+													<Lock
+														className="size-3.5"
+														weight="duotone"
+													/>
+												)
+											}
+										>
+											{app.visibility === 'private'
+												? 'Publish'
+												: 'Unpublish'}
+										</Button>
+									)}
+									{app && (
+										<DropdownMenu>
+											<DropdownMenu.Trigger
+												render={
+													<Button
+														variant="secondary"
+														size="sm"
+														shape="square"
+														aria-label="More actions"
+														icon={
+															<DotsThree className="h-4 w-4" />
+														}
+													/>
+												}
+											/>
+											<DropdownMenu.Content align="end">
+												<DropdownMenu.Item
+													icon={BookmarkSimpleIcon}
+													onClick={() => {
+														void handleFavorite();
+													}}
+												>
+													{isFavorited
+														? 'Bookmarked'
+														: 'Bookmark'}
+												</DropdownMenu.Item>
+												<DropdownMenu.Item
+													icon={GitBranch}
+													onClick={() =>
+														setIsGitCloneModalOpen(
+															true,
+														)
+													}
+												>
+													Clone
+												</DropdownMenu.Item>
+											</DropdownMenu.Content>
+										</DropdownMenu>
+									)}
+								</div>
+							</>
 						)}
 					</div>
 				)}
@@ -1104,30 +1265,32 @@ export default function Chat() {
 												onResumeGeneration={
 													handleResumeGeneration
 												}
-											onVisibilityUpdate={(
-												newVisibility,
-											) => {
-												if (!app?.id) return;
+												onVisibilityUpdate={(
+													newVisibility,
+												) => {
+													if (!app?.id) return;
 
-												queryClient.setQueryData<AppDetailsData>(
-													queryKeys.account.apps.detail(
-														app.id,
-														user?.id,
-													),
-													(prev) =>
-														prev
-															? {
-																	...prev,
-																	visibility:
-																		newVisibility,
-																}
-															: prev,
-												);
-												void queryClient.invalidateQueries({
-													queryKey:
-														queryKeys.account.apps.all(),
-												});
-											}}
+													queryClient.setQueryData<AppDetailsData>(
+														queryKeys.account.apps.detail(
+															app.id,
+															user?.id,
+														),
+														(prev) =>
+															prev
+																? {
+																		...prev,
+																		visibility:
+																			newVisibility,
+																	}
+																: prev,
+													);
+													void queryClient.invalidateQueries(
+														{
+															queryKey:
+																queryKeys.account.apps.all(),
+														},
+													);
+												}}
 											/>
 										</motion.div>
 									)}

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -18,7 +18,7 @@ import { useAuthGuard } from '../hooks/useAuthGuard';
 import { usePaginatedApps } from '@/hooks/use-paginated-apps';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import { AppCard } from '@/components/shared/AppCard';
-import { Button } from '@/components/ui/button';
+import { LinkButton } from '@cloudflare/kumo';
 import clsx from 'clsx';
 import { useImageUpload } from '@/hooks/use-image-upload';
 import { useDragDrop } from '@/hooks/use-drag-drop';
@@ -309,17 +309,14 @@ export default function Home() {
 										</h2>
 									</div>
 									<div ref={discoverLinkRef}>
-										<Button
+										<LinkButton
 											variant="outline"
 											size="sm"
-											onClick={() =>
-												navigate('/discover')
-											}
-											className="shrink-0 rounded-full px-3.5 gap-1.5 text-sm text-kumo-default ring-1 ring-kumo-line border-0 shadow-sm hover:bg-kumo-tint hover:text-kumo-strong"
+											href="/discover"
 										>
 											View all
 											<ArrowUpRight className="size-3.5 opacity-70" />
-										</Button>
+										</LinkButton>
 									</div>
 								</div>
 								<motion.div

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -204,7 +204,7 @@ export default function Home() {
 						)}
 					>
 						<div className="mb-6 sm:mb-7 grid gap-2">
-							<h1 className="w-full text-center text-[clamp(1.75rem,4.5vw,2.5rem)] font-semibold leading-[1.12] text-kumo-strong/80">
+							<h1 className="w-full text-center text-[clamp(1.75rem,4.5vw,2.5rem)] font-semibold leading-[1.12] text-kumo-strong/80 z-20">
 								What should we{' '}
 								<span className="font-funky-mono text-[1.1em] tracking-tighter uppercase text-brand">
 									build

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -231,7 +231,7 @@ export default function SettingsPage() {
 					<CloudflareAccountSelector />
 
 					<LayerCard id="api-keys">
-						<LayerCard.Secondary>
+						<LayerCard.Secondary className="font-funky-mono tracking-tighter">
 							<div className="flex items-center gap-2">
 								<span className="flex items-center">
 									<Key className="size-4" />
@@ -603,7 +603,7 @@ export default function SettingsPage() {
 
 					{/* Security Section */}
 					<LayerCard id="security">
-						<LayerCard.Secondary>
+						<LayerCard.Secondary className="font-funky-mono tracking-tighter">
 							<div className="flex items-center gap-2">
 								<span className="h-lh flex items-center">
 									<Lock className="size-4" />
@@ -683,7 +683,7 @@ export default function SettingsPage() {
 					</LayerCard>
 
 					<LayerCard id="danger-zone">
-						<LayerCard.Secondary>
+						<LayerCard.Secondary className="font-funky-mono tracking-tighter">
 							<span className="text-kumo-danger">
 								Danger zone
 							</span>

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -214,7 +214,7 @@ export default function SettingsPage() {
 	}, [apiKeysError]);
 
 	return (
-		<div className="size-full bg-kumo-base relative">
+		<div className="relative">
 			<main className="container mx-auto px-4 py-16 max-w-4xl pb-48">
 				<div className="grid gap-8">
 					{/* Page Header */}


### PR DESCRIPTION
Batch of UI polish for the latest revamp sprint.

- Added `AppLinkProvider` so Kumo `LinkButton`/`Link` components route through `react-router` internally and fall back to plain anchors for external URLs.
- Replaced the homepage "View all" button with a Kumo `LinkButton` that uses the new provider.
- Brought app actions into the chat page header:
  - Owners can publish/unpublish the app via a visibility toggle.
  - Bookmark/unbookmark toggle.
  - Clone action in a dropdown (re-using GitHub export flow).
- Replaced inline visibility icons with a Kumo `Badge`.
- Migrated chat page rollback and error toasts from `sonner` to `useKumoToastManager`.
- Settings page: removed fixed `bg-kumo-base` so the background fills full height, and applied `font-funky-mono` to section headers and the account selector card.
