### PR TITLE
fix(layout): use global header with sidebar toggle and sign-in button

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@babel/traverse": "^7.28.5",
         "@babel/types": "^7.28.5",
         "@cloudflare/containers": "^0.0.28",
-        "@cloudflare/kumo": "^2.8.0",
+        "@cloudflare/kumo": "^2.9.0",
         "@cloudflare/puppeteer": "^1.0.4",
         "@cloudflare/sandbox": "0.5.6",
         "@cloudflare/think": "^0.8.6",
@@ -309,7 +309,7 @@
 
     "@cloudflare/containers": ["@cloudflare/containers@0.0.28", "", {}, "sha512-wzR9UWcGvZ9znd4elkXklilPcHX6srncsjSkx696SZRZyTygNbWsLlHegvc1C+e9gn28HRZU3dLiAzXiC9IY1w=="],
 
-    "@cloudflare/kumo": ["@cloudflare/kumo@2.8.0", "", { "dependencies": { "@base-ui/react": "^1.6.0", "@shikijs/langs": "^4.0.0", "@shikijs/themes": "^4.0.0", "cnfast": "^0.0.8", "d3-geo": "^3.1.1", "motion": "^12.34.1", "react-day-picker": "^9.13.2", "shiki": "^4.0.0" }, "peerDependencies": { "@phosphor-icons/react": "^2.1.10", "echarts": "^6.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "zod": "^4.0.0" }, "optionalPeers": ["echarts", "zod"], "bin": { "kumo": "bin/kumo.js" } }, "sha512-zhS8m73xSqoWeUs1KvhancIm5lz8xMqk4OPDoX6q+ffqwSGXNchXzUv987eEI7Q8wg2eJEwXHuL/joc0u79Xwg=="],
+    "@cloudflare/kumo": ["@cloudflare/kumo@2.9.0", "", { "dependencies": { "@base-ui/react": "^1.6.0", "@shikijs/langs": "^4.0.0", "@shikijs/themes": "^4.0.0", "cnfast": "^0.0.8", "d3-geo": "^3.1.1", "motion": "^12.34.1", "react-day-picker": "^9.13.2", "shiki": "^4.0.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@phosphor-icons/react": "^2.1.10", "echarts": "^6.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "zod": "^4.0.0" }, "optionalPeers": ["echarts", "zod"], "bin": { "kumo": "bin/kumo.js" } }, "sha512-WkJNwJrT/VDfBFckscrhnxKbAu9hRC/iWxzUB4tWu1OAHo3hx4PQ0cbT6wxoye54jns6m13Acq7SIzw5uY0Qcw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/traverse": "^7.28.5",
 		"@babel/types": "^7.28.5",
 		"@cloudflare/containers": "^0.0.28",
-		"@cloudflare/kumo": "^2.8.0",
+		"@cloudflare/kumo": "^2.9.0",
 		"@cloudflare/puppeteer": "^1.0.4",
 		"@cloudflare/sandbox": "0.5.6",
 		"@cloudflare/think": "^0.8.6",

--- a/src/components/auth/auth-button.tsx
+++ b/src/components/auth/auth-button.tsx
@@ -1,21 +1,19 @@
 /**
- * Enhanced Auth Button
- * Provides OAuth + Email/Password authentication with enhanced UI
+ * Auth Button
+ * Account menu for authenticated users
  */
 
-import { useState } from 'react';
 import { Loader2, LucideGlobeLock } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { cn, Button, DropdownMenu } from '@cloudflare/kumo';
 import { useAuth } from '../../contexts/auth-context';
-import { LoginModal } from './login-modal';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { Skeleton } from '../ui/skeleton';
 import {
 	useUsageLimitsBadgeState,
 	type UsageLimitsBadgeState,
 } from '../usage-limits-badge';
-import { GearIcon, SignInIcon, SignOutIcon } from '@phosphor-icons/react';
+import { GearIcon, SignOutIcon } from '@phosphor-icons/react';
 
 interface AuthButtonProps {
 	className?: string;
@@ -45,20 +43,9 @@ function getLimitsDetailText(limits: UsageLimitsBadgeState) {
 }
 
 export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
-	const {
-		user,
-		isAuthenticated,
-		isLoading,
-		error,
-		login, // OAuth method
-		loginWithEmail,
-		register,
-		logout,
-		clearError,
-	} = useAuth();
+	const { user, isAuthenticated, isLoading, logout } = useAuth();
 
 	const navigate = useNavigate();
-	const [showLoginModal, setShowLoginModal] = useState(false);
 	const usageLimits = useUsageLimitsBadgeState();
 	const showLimitsState = !usageLimits.hidden;
 	const limitsStatusText = getLimitsStatusText(usageLimits);
@@ -74,51 +61,9 @@ export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
 	}
 
 	if (!isAuthenticated || !user) {
-		return (
-			<>
-				<Button
-					variant="ghost"
-					onClick={() => setShowLoginModal(true)}
-					className={cn('gap-2 text-sm', className)}
-				>
-					<SignInIcon className="h-4 w-4" />
-					<span>Sign In</span>
-				</Button>
-
-				<LoginModal
-					isOpen={showLoginModal}
-					onClose={() => setShowLoginModal(false)}
-					onLogin={(provider: 'google' | 'github' | 'cloudflare') => {
-						// For backward compatibility with original login interface
-						login(provider);
-						setShowLoginModal(false);
-					}}
-					onEmailLogin={async (credentials) => {
-						await loginWithEmail(credentials);
-						if (!error) {
-							setShowLoginModal(false);
-						}
-					}}
-					onOAuthLogin={(
-						provider: 'google' | 'github' | 'cloudflare',
-					) => {
-						login(provider);
-						setShowLoginModal(false);
-					}}
-					onRegister={async (data) => {
-						await register(data);
-						if (!error) {
-							setShowLoginModal(false);
-						}
-					}}
-					error={error}
-					onClearError={clearError}
-				/>
-			</>
-		);
+		return null;
 	}
 
-	// Get user initials for avatar fallback
 	const getInitials = () => {
 		if (user.displayName) {
 			return user.displayName

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Outlet } from 'react-router';
 import { SidebarProvider, useSidebar } from '@cloudflare/kumo';
 import { AppSidebar } from './app-sidebar';
+import { GlobalHeader } from './global-header';
+import { HeaderProvider } from './header-context';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -49,22 +51,24 @@ export function AppLayout({ children }: AppLayoutProps) {
 
 	return (
 		<SidebarProvider
-			// remove once sidebar toggle is added to main content in mobile breakpoints
-			mobileBreakpoint={0}
 			defaultOpen={defaultOpen}
 			collapsible="icon"
 			resizable={false}
+			mobileBreakpoint={768}
 			// peekable
 			onOpenChange={persistSidebarState}
 			className="vibesdk-sidebar-wrapper"
 		>
-			<SidebarKeyboardShortcut />
-			<AppSidebar />
-			<main className="bg-kumo-canvas flex flex-col h-screen relative flex-1 min-w-0 overflow-hidden">
-				<div className="flex-1 min-h-0 overflow-auto bg-kumo-canvas">
-					{children || <Outlet />}
-				</div>
-			</main>
+			<HeaderProvider>
+				<SidebarKeyboardShortcut />
+				<AppSidebar />
+				<main className="bg-kumo-canvas flex flex-col h-screen relative flex-1 min-w-0 overflow-hidden">
+					<GlobalHeader />
+					<div className="flex-1 min-h-0 overflow-auto bg-kumo-canvas">
+						{children || <Outlet />}
+					</div>
+				</main>
+			</HeaderProvider>
 		</SidebarProvider>
 	);
 }

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -589,7 +589,7 @@ export function AppSidebar() {
 						</button>
 					)}
 					<div className="flex min-w-0 w-full items-center gap-2 group-data-[state=collapsed]/sidebar:flex-col">
-						{(!isCollapsed || user) && (
+						{user && (
 							<div className="min-w-0 flex-1">
 								<AuthButton
 									display="sidebar"

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,30 +1,23 @@
 import React from 'react';
-import { ChevronRight, Plus, PlusIcon, Search, Users } from 'lucide-react';
 import {
 	BookmarkSimpleIcon,
+	CaretRightIcon,
 	CompassIcon,
 	GlobeHemisphereWestIcon,
-	LockKey,
-	UsersThree,
+	LockKeyIcon,
+	MagnifyingGlassIcon,
+	PlusIcon,
+	UsersThreeIcon,
 } from '@phosphor-icons/react';
 import { isValid } from 'date-fns';
 import { useLocation, useNavigate } from 'react-router';
 import {
+	Button,
 	CloudflareLogo,
 	InputGroup,
 	Sidebar,
-	SidebarContent,
-	SidebarFooter,
-	SidebarGroup,
-	SidebarHeader,
-	SidebarGroupLabel,
-	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
-	SidebarSeparator,
-	SidebarTrigger,
-	useSidebar,
 	cn,
+	useSidebar,
 } from '@cloudflare/kumo';
 import { useAuth } from '@/contexts/auth-context';
 import { useApps, useFavoriteApps, useRecentApps } from '@/hooks/use-apps';
@@ -102,8 +95,8 @@ function AppMenuItem({
 	};
 
 	return (
-		<SidebarMenuItem className="group/app-item">
-			<SidebarMenuButton
+		<Sidebar.MenuItem className="group/app-item">
+			<Sidebar.MenuButton
 				active={active}
 				href={`/app/${app.id}`}
 				tooltip={app.title}
@@ -131,7 +124,7 @@ function AppMenuItem({
 						<span className="truncate">{formatTimestamp()}</span>
 					</span>
 				</span>
-			</SidebarMenuButton>
+			</Sidebar.MenuButton>
 
 			{!isCollapsed && showActions && (
 				<div className="absolute right-1.5 top-1/2 z-10 -translate-y-1/2 opacity-0 transition-opacity group-hover/app-item:opacity-100 focus-within:opacity-100">
@@ -144,7 +137,7 @@ function AppMenuItem({
 					/>
 				</div>
 			)}
-		</SidebarMenuItem>
+		</Sidebar.MenuItem>
 	);
 }
 
@@ -153,10 +146,6 @@ export function AppSidebar() {
 	const navigate = useNavigate();
 	const { pathname } = useLocation();
 	const [searchQuery, setSearchQuery] = React.useState('');
-	const [expandedGroups, setExpandedGroups] = React.useState<string[]>([
-		'apps',
-		'boards',
-	]);
 	const { state } = useSidebar();
 	const isCollapsed = state === 'collapsed';
 	const usageLimits = useUsageLimitsBadgeState();
@@ -245,16 +234,12 @@ export function AppSidebar() {
 	const getVisibilityIcon = (visibility: App['visibility']) => {
 		switch (visibility) {
 			case 'private':
-				return <LockKey className="size-3.5" weight="duotone" />;
+				return <LockKeyIcon className="size-3.5" weight="duotone" />;
 			case 'team':
-				return <UsersThree className="size-3.5" weight="duotone" />;
-			case 'board':
 				return (
-					<GlobeHemisphereWestIcon
-						className="size-3.5"
-						weight="duotone"
-					/>
+					<UsersThreeIcon className="size-3.5" weight="duotone" />
 				);
+			case 'board':
 			case 'public':
 				return (
 					<GlobeHemisphereWestIcon
@@ -265,135 +250,161 @@ export function AppSidebar() {
 		}
 	};
 
-	const toggleGroup = (group: string) => {
-		setExpandedGroups((prev) =>
-			prev.includes(group)
-				? prev.filter((g) => g !== group)
-				: [...prev, group],
-		);
-	};
-
-	// if (!user) return null;
-
 	return (
-		<Sidebar
-			contentClassName=""
-			className="[--sidebar-bg:var(--color-kumo-canvas)]"
-		>
-			<SidebarHeader className="h-12 justify-start px-4 pr-2 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0">
-				<div className="flex w-full items-center gap-2.5 text-kumo-strong group-data-[state=collapsed]/sidebar:justify-center">
-					<CloudflareLogo
-						variant="glyph"
-						className="size-7 shrink-0 group-data-[state=collapsed]/sidebar:hidden group-data-[mobile=true]/sidebar:block"
-					/>
-					<span className="truncate text-sm font-black font-funky-mono uppercase tracking-[0.25em] group-data-[state=collapsed]/sidebar:hidden group-data-[mobile=true]/sidebar:inline">
-						Build
-					</span>
-					<SidebarTrigger
-						aria-label={
-							isCollapsed ? 'Open sidebar' : 'Collapse sidebar'
-						}
-						className="ml-auto group-data-[state=collapsed]/sidebar:ml-0"
-					/>
-				</div>
-			</SidebarHeader>
-			<SidebarContent>
-				{/* Full-bleed when collapsed: content uses px-[11px], so expand width to fit size-9 */}
-				<SidebarGroup className="gap-2 py-1 group-data-[state=collapsed]/sidebar:w-[calc(100%+22px)] group-data-[state=collapsed]/sidebar:min-w-[calc(100%+22px)] group-data-[state=collapsed]/sidebar:-ml-[11px] group-data-[state=collapsed]/sidebar:items-center">
-					<SidebarMenu className="gap-1 group-data-[state=collapsed]/sidebar:w-full group-data-[state=collapsed]/sidebar:items-center">
-						{pathname !== '/' && (
-							<Sidebar.MenuButton
-								icon={PlusIcon}
-								className={cn(
-									'bg-brand text-white hover:bg-brand/80 dark:bg-brand/80 dark:hover:bg-brand',
-									// Square, centered icon when collapsed (match ThemeToggle)
-									'group-data-[state=collapsed]/sidebar:size-9 group-data-[state=collapsed]/sidebar:w-9 group-data-[state=collapsed]/sidebar:min-h-9 group-data-[state=collapsed]/sidebar:min-w-9 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0 group-data-[state=collapsed]/sidebar:py-0',
-									'group-data-[state=collapsed]/sidebar:[&>div]:translate-x-0 group-data-[state=collapsed]/sidebar:[&>div]:flex-none group-data-[state=collapsed]/sidebar:[&>div]:justify-center',
-									'group-data-[state=collapsed]/sidebar:[&>div>span]:hidden',
-								)}
-								tooltip="New build"
-								onClick={() => navigate('/')}
-							>
-								New build
-							</Sidebar.MenuButton>
-						)}
+		<Sidebar className="[--sidebar-bg:var(--color-kumo-canvas)]">
+			<Sidebar.Header
+				className={cn('h-12', isCollapsed ? 'justify-center px-0' : 'px-3')}
+			>
+				{isCollapsed ? (
+					<div className="relative flex size-9 items-center justify-center">
+						<CloudflareLogo
+							variant="glyph"
+							className="size-7 shrink-0 transition-opacity group-hover/sidebar:opacity-0 group-focus-within/sidebar:opacity-0"
+						/>
+						<Sidebar.Trigger
+							aria-label="Open sidebar"
+							className="absolute inset-0 flex size-9 items-center justify-center opacity-0 transition-opacity group-hover/sidebar:opacity-100 group-focus-within/sidebar:opacity-100"
+						/>
+					</div>
+				) : (
+					<div className="flex w-full min-w-0 items-center gap-2.5 text-kumo-strong">
+						<CloudflareLogo
+							variant="glyph"
+							className="size-7 shrink-0"
+						/>
+						<span className="min-w-0 flex-1 truncate text-sm font-black font-funky-mono uppercase tracking-[0.25em]">
+							Build
+						</span>
+						<Sidebar.Trigger
+							aria-label="Collapse sidebar"
+							className="ml-auto shrink-0"
+						/>
+					</div>
+				)}
+			</Sidebar.Header>
 
-						<Sidebar.MenuButton
-							active={pathname === '/discover'}
-							icon={CompassIcon}
-							id="discover-link"
-							tooltip="Discover"
-							className={cn(
-								'group-data-[state=collapsed]/sidebar:size-9 group-data-[state=collapsed]/sidebar:w-9 group-data-[state=collapsed]/sidebar:min-h-9 group-data-[state=collapsed]/sidebar:min-w-9 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0 group-data-[state=collapsed]/sidebar:py-0',
-								'group-data-[state=collapsed]/sidebar:[&>div]:translate-x-0 group-data-[state=collapsed]/sidebar:[&>div]:flex-none group-data-[state=collapsed]/sidebar:[&>div]:justify-center',
-								'group-data-[state=collapsed]/sidebar:[&>div>span]:hidden',
-							)}
-							onClick={() => navigate('/discover')}
-						>
-							Discover
-						</Sidebar.MenuButton>
-
-						{!isCollapsed && user && (
-							<InputGroup>
-								<InputGroup.Addon>
-									<Search className="size-3.5 text-kumo-subtle" />
-								</InputGroup.Addon>
-								<InputGroup.Input
-									aria-label="Search apps"
-									placeholder="Search apps"
-									value={searchQuery}
-									onChange={(event) =>
-										setSearchQuery(event.target.value)
-									}
+			<Sidebar.Content>
+				<Sidebar.Group>
+					{isCollapsed ? (
+						<div className="flex flex-col items-center gap-1">
+							{pathname !== '/' && (
+								<Button
+									shape="square"
+									size="base"
+									aria-label="New build"
+									title="New build"
+									onClick={() => navigate('/')}
+									className="bg-brand text-white shadow-none ring-0 hover:bg-brand/80"
+									icon={<PlusIcon className="size-4" weight="bold" />}
 								/>
-							</InputGroup>
-						)}
-					</SidebarMenu>
-				</SidebarGroup>
+							)}
+							<Button
+								shape="square"
+								size="base"
+								variant="ghost"
+								id="discover-link"
+								aria-label="Discover"
+								title="Discover"
+								aria-current={
+									pathname === '/discover' ? 'page' : undefined
+								}
+								onClick={() => navigate('/discover')}
+								className={cn(
+									'text-kumo-subtle hover:text-kumo-default',
+									pathname === '/discover' &&
+										'bg-(--sidebar-active-bg) text-kumo-default',
+								)}
+								icon={<CompassIcon className="size-4" />}
+							/>
+						</div>
+					) : (
+						<div className="flex flex-col gap-1.5">
+							<Sidebar.Menu className="gap-y-1.5">
+								{pathname !== '/' && (
+									<Sidebar.MenuButton
+										icon={PlusIcon}
+										className="bg-brand text-white hover:bg-brand/80"
+										tooltip="New build"
+										onClick={() => navigate('/')}
+									>
+										New build
+									</Sidebar.MenuButton>
+								)}
+
+								<Sidebar.MenuButton
+									active={pathname === '/discover'}
+									icon={CompassIcon}
+									id="discover-link"
+									tooltip="Discover"
+									onClick={() => navigate('/discover')}
+								>
+									Discover
+								</Sidebar.MenuButton>
+							</Sidebar.Menu>
+
+							{user && (
+								<div className="px-0.5">
+									<InputGroup>
+										<InputGroup.Addon>
+											<MagnifyingGlassIcon className="size-3.5 text-kumo-subtle" />
+										</InputGroup.Addon>
+										<InputGroup.Input
+											aria-label="Search apps"
+											placeholder="Search apps"
+											value={searchQuery}
+											onChange={(event) =>
+												setSearchQuery(
+													event.target.value,
+												)
+											}
+										/>
+									</InputGroup>
+								</div>
+							)}
+						</div>
+					)}
+				</Sidebar.Group>
 
 				{!isCollapsed && showBookmarksSection && (
-					<SidebarGroup className="">
-						<SidebarGroupLabel className="flex items-center">
+					<Sidebar.Group>
+						<Sidebar.GroupLabel>
 							<span className="text-xs font-funky-mono">
 								Bookmarked
 							</span>
-						</SidebarGroupLabel>
-						<SidebarMenu>
+						</Sidebar.GroupLabel>
+						<Sidebar.Menu>
 							{isSearching ? (
-								<>
-									{favoriteAppsLoading ? (
-										<SidebarMenuItem>
-											<div className="px-3 py-3 text-sm text-kumo-subtle">
-												Searching bookmarks...
-											</div>
-										</SidebarMenuItem>
-									) : favoriteSearchResults.length > 0 ? (
-										favoriteSearchResults.map((app) => (
-											<AppMenuItem
-												key={app.id}
-												app={app}
-												active={
-													pathname ===
-													`/app/${app.id}`
-												}
-												onClick={(id) =>
-													navigate(`/app/${id}`)
-												}
-												variant="bookmarked"
-												isCollapsed={isCollapsed}
-												getVisibilityIcon={
-													getVisibilityIcon
-												}
-											/>
-										))
-									) : (
-										<SidebarMenuItem>
-											<div className="px-3 py-3 text-sm text-kumo-subtle">
-												{bookmarkSearchEmptyMessage}
-											</div>
-										</SidebarMenuItem>
-									)}
-								</>
+								favoriteAppsLoading ? (
+									<Sidebar.MenuItem>
+										<div className="px-3 py-3 text-sm text-kumo-subtle">
+											Searching bookmarks...
+										</div>
+									</Sidebar.MenuItem>
+								) : favoriteSearchResults.length > 0 ? (
+									favoriteSearchResults.map((app) => (
+										<AppMenuItem
+											key={app.id}
+											app={app}
+											active={
+												pathname === `/app/${app.id}`
+											}
+											onClick={(id) =>
+												navigate(`/app/${id}`)
+											}
+											variant="bookmarked"
+											isCollapsed={isCollapsed}
+											getVisibilityIcon={
+												getVisibilityIcon
+											}
+										/>
+									))
+								) : (
+									<Sidebar.MenuItem>
+										<div className="px-3 py-3 text-sm text-kumo-subtle">
+											{bookmarkSearchEmptyMessage}
+										</div>
+									</Sidebar.MenuItem>
+								)
 							) : (
 								favoriteApps.map((app) => (
 									<AppMenuItem
@@ -407,161 +418,144 @@ export function AppSidebar() {
 									/>
 								))
 							)}
-						</SidebarMenu>
-					</SidebarGroup>
+						</Sidebar.Menu>
+					</Sidebar.Group>
 				)}
 
-				{!isCollapsed &&
-					showAppsSection &&
-					expandedGroups.includes('apps') && (
-						<SidebarGroup className="">
-							<SidebarMenu>
-								<SidebarGroupLabel className="flex items-center">
-									<span className="text-xs font-funky-mono">
-										Apps
-									</span>
-								</SidebarGroupLabel>
-								{isSearching ? (
-									<>
-										{allAppsLoading ? (
-											<SidebarMenuItem>
-												<div className="px-3 py-3 text-sm text-kumo-subtle">
-													Searching apps...
-												</div>
-											</SidebarMenuItem>
-										) : appSearchResults.length > 0 ? (
-											appSearchResults.map((app) => (
-												<AppMenuItem
-													key={app.id}
-													app={app}
-													active={
-														pathname ===
-														`/app/${app.id}`
-													}
-													onClick={(id) =>
-														navigate(`/app/${id}`)
-													}
-													isCollapsed={isCollapsed}
-													getVisibilityIcon={
-														getVisibilityIcon
-													}
-												/>
-											))
-										) : (
-											<SidebarMenuItem>
-												<div className="px-3 py-3 text-sm text-kumo-subtle">
-													{appSearchEmptyMessage}
-												</div>
-											</SidebarMenuItem>
-										)}
-									</>
+				{!isCollapsed && showAppsSection && (
+					<Sidebar.Group>
+						<Sidebar.GroupLabel>
+							<span className="text-xs font-funky-mono">
+								Apps
+							</span>
+						</Sidebar.GroupLabel>
+						<Sidebar.Menu>
+							{isSearching ? (
+								allAppsLoading ? (
+									<Sidebar.MenuItem>
+										<div className="px-3 py-3 text-sm text-kumo-subtle">
+											Searching apps...
+										</div>
+									</Sidebar.MenuItem>
+								) : appSearchResults.length > 0 ? (
+									appSearchResults.map((app) => (
+										<AppMenuItem
+											key={app.id}
+											app={app}
+											active={
+												pathname === `/app/${app.id}`
+											}
+											onClick={(id) =>
+												navigate(`/app/${id}`)
+											}
+											isCollapsed={isCollapsed}
+											getVisibilityIcon={
+												getVisibilityIcon
+											}
+										/>
+									))
 								) : (
-									<>
-										{appsWithoutBookmarks.map((app) => (
-											<AppMenuItem
-												key={app.id}
-												app={app}
-												active={
-													pathname ===
-													`/app/${app.id}`
-												}
-												onClick={(id) =>
-													navigate(`/app/${id}`)
-												}
-												isCollapsed={isCollapsed}
-												getVisibilityIcon={
-													getVisibilityIcon
-												}
-											/>
-										))}
-										{moreAvailable && (
-											<SidebarMenuButton
-												active={pathname === '/apps'}
-												icon={
-													<ChevronRight className="size-4 text-kumo-subtle" />
-												}
-												tooltip="View all apps"
-												onClick={() =>
-													navigate('/apps')
-												}
-											>
-												View all apps
-											</SidebarMenuButton>
-										)}
-									</>
-								)}
-							</SidebarMenu>
-						</SidebarGroup>
-					)}
+									<Sidebar.MenuItem>
+										<div className="px-3 py-3 text-sm text-kumo-subtle">
+											{appSearchEmptyMessage}
+										</div>
+									</Sidebar.MenuItem>
+								)
+							) : (
+								<>
+									{appsWithoutBookmarks.map((app) => (
+										<AppMenuItem
+											key={app.id}
+											app={app}
+											active={
+												pathname === `/app/${app.id}`
+											}
+											onClick={(id) =>
+												navigate(`/app/${id}`)
+											}
+											isCollapsed={isCollapsed}
+											getVisibilityIcon={
+												getVisibilityIcon
+											}
+										/>
+									))}
+									{moreAvailable && (
+										<Sidebar.MenuButton
+											active={pathname === '/apps'}
+											icon={CaretRightIcon}
+											tooltip="View all apps"
+											onClick={() => navigate('/apps')}
+										>
+											View all apps
+										</Sidebar.MenuButton>
+									)}
+								</>
+							)}
+						</Sidebar.Menu>
+					</Sidebar.Group>
+				)}
 
 				{!isCollapsed && boards.length > 0 && (
 					<>
-						<SidebarSeparator />
-						<SidebarGroup className="py-2">
-							<SidebarGroupLabel
-								className="cursor-pointer"
-								onClick={() => toggleGroup('boards')}
-							>
-								<span className="flex items-center justify-between">
-									<span className="flex items-center gap-2">
-										<Users className="size-3.5" />
-										<span>My Boards</span>
-									</span>
-									<ChevronRight
-										className={cn(
-											'size-3.5 transition-transform',
-											expandedGroups.includes('boards') &&
-												'rotate-90',
-										)}
-									/>
-								</span>
-							</SidebarGroupLabel>
-							{expandedGroups.includes('boards') && (
-								<SidebarMenu>
-									{boards.map((board) => (
-										<SidebarMenuButton
-											key={board.id}
-											icon={
-												<UsersThree
-													className="size-4"
-													weight="duotone"
-												/>
+						<Sidebar.Separator />
+						<Sidebar.Group>
+							<Sidebar.Menu>
+								<Sidebar.MenuItem>
+									<Sidebar.Collapsible defaultOpen>
+										<Sidebar.CollapsibleTrigger
+											render={
+												<Sidebar.MenuButton
+													icon={UsersThreeIcon}
+												>
+													My boards
+													<Sidebar.MenuChevron />
+												</Sidebar.MenuButton>
 											}
-											tooltip={board.name}
-											onClick={() =>
-												navigate(
-													`/boards/${board.slug}`,
-												)
-											}
-										>
-											<span className="flex min-w-0 flex-col gap-0.5">
-												<span className="truncate">
-													{board.name}
-												</span>
-												<span className="truncate text-xs font-normal text-kumo-subtle">
-													{board.memberCount} members
-													/ {board.appCount} apps
-												</span>
-											</span>
-										</SidebarMenuButton>
-									))}
-									<SidebarMenuButton
-										icon={
-											<Plus className="size-4 text-kumo-subtle" />
-										}
-										tooltip="Browse all boards"
-										onClick={() => navigate('/boards')}
-									>
-										Browse all boards
-									</SidebarMenuButton>
-								</SidebarMenu>
-							)}
-						</SidebarGroup>
+										/>
+										<Sidebar.CollapsibleContent>
+											<Sidebar.MenuSub>
+												{boards.map((board) => (
+													<Sidebar.MenuSubButton
+														key={board.id}
+														onClick={() =>
+															navigate(
+																`/boards/${board.slug}`,
+															)
+														}
+													>
+														<span className="flex min-w-0 flex-col gap-0.5">
+															<span className="truncate">
+																{board.name}
+															</span>
+															<span className="truncate text-xs font-normal text-kumo-subtle">
+																{
+																	board.memberCount
+																}{' '}
+																members /{' '}
+																{board.appCount}{' '}
+																apps
+															</span>
+														</span>
+													</Sidebar.MenuSubButton>
+												))}
+												<Sidebar.MenuSubButton
+													onClick={() =>
+														navigate('/boards')
+													}
+												>
+													Browse all boards
+												</Sidebar.MenuSubButton>
+											</Sidebar.MenuSub>
+										</Sidebar.CollapsibleContent>
+									</Sidebar.Collapsible>
+								</Sidebar.MenuItem>
+							</Sidebar.Menu>
+						</Sidebar.Group>
 					</>
 				)}
-			</SidebarContent>
+			</Sidebar.Content>
 
-			<SidebarFooter className="h-auto border-t border-kumo-line p-3">
+			<Sidebar.Footer className="h-auto p-3">
 				<div className="flex w-full min-w-0 flex-col gap-2">
 					{showCloudflareCta && (
 						<button
@@ -588,22 +582,31 @@ export function AppSidebar() {
 							)}
 						</button>
 					)}
-					<div className="flex min-w-0 w-full items-center gap-2 group-data-[state=collapsed]/sidebar:flex-col">
+					<div
+						className={cn(
+							'flex min-w-0 w-full items-center gap-2',
+							isCollapsed && 'flex-col',
+						)}
+					>
 						{user && (
 							<div className="min-w-0 flex-1">
 								<AuthButton
 									display="sidebar"
-									className="group-data-[state=collapsed]/sidebar:size-9 group-data-[state=collapsed]/sidebar:flex-none group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0 w-full"
+									className={cn(
+										'w-full',
+										isCollapsed &&
+											'size-9 flex-none justify-center px-0',
+									)}
 								/>
 							</div>
 						)}
 						<ThemeToggle
 							align="end"
-							className="size-9 shrink-0 rounded-lg group-data-[state=collapsed]/sidebar:ml-0"
+							className="size-9 shrink-0 rounded-lg"
 						/>
 					</div>
 				</div>
-			</SidebarFooter>
+			</Sidebar.Footer>
 		</Sidebar>
 	);
 }

--- a/src/components/layout/global-header.tsx
+++ b/src/components/layout/global-header.tsx
@@ -1,21 +1,37 @@
 import { useEffect, useState } from 'react';
-import { SidebarTrigger, cn } from '@cloudflare/kumo';
-import { motion } from 'framer-motion';
+import { SidebarTrigger, cn, useSidebar } from '@cloudflare/kumo';
 import { useAuth } from '@/contexts/auth-context';
 import { ChevronRight, AlertCircle } from 'lucide-react';
+import { SignInIcon } from '@phosphor-icons/react';
 import { usePlatformStatus } from '@/hooks/use-platform-status';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useLocation } from 'react-router';
-import { AuthButton } from '../auth/auth-button';
+import { useAuthModal } from '../auth/AuthModalProvider';
+import { useHeaderContent } from './header-context';
 
 export function GlobalHeader() {
-	const { user } = useAuth();
+	const { user, isLoading: authLoading } = useAuth();
+	const { showAuthModal } = useAuthModal();
+	const { isMobile } = useSidebar();
+	const { content } = useHeaderContent();
 	const { status } = usePlatformStatus();
 	const [isChangelogOpen, setIsChangelogOpen] = useState(false);
-	const hasMaintenanceMessage = Boolean(status.hasActiveMessage && status.globalUserMessage.trim().length > 0);
-	const hasChangeLogs = Boolean(status.changeLogs && status.changeLogs.trim().length > 0);
+	const hasMaintenanceMessage = Boolean(
+		status.hasActiveMessage && status.globalUserMessage.trim().length > 0,
+	);
+	const hasChangeLogs = Boolean(
+		status.changeLogs && status.changeLogs.trim().length > 0,
+	);
 	const { pathname } = useLocation();
+	const hasPageContent = Boolean(content?.leading || content?.trailing);
+
 	useEffect(() => {
 		if (!hasChangeLogs) {
 			setIsChangelogOpen(false);
@@ -23,97 +39,83 @@ export function GlobalHeader() {
 	}, [hasChangeLogs]);
 
 	return (
-		<Dialog open={isChangelogOpen} onOpenChange={setIsChangelogOpen}>
-			<motion.header
-				initial={{ y: -10, opacity: 0 }}
-				animate={{ y: 0, opacity: 1 }}
-				transition={{ duration: 0.2, ease: 'easeOut' }}
-				className={cn("sticky top-0 z-50", pathname !== "/" && "bg-kumo-base")}
+		<>
+			<header
+				className={cn(
+					'sticky top-0 z-10',
+					pathname !== '/' && 'bg-kumo-base',
+				)}
 			>
-				<div className="relative">
-					{/* Subtle gradient accent */}
-					<div className="absolute inset-0 z-0" />
+				<div className="relative flex h-12 items-center gap-2 border-b border-kumo-line pl-2 pr-3 md:gap-3 md:px-4">
+					{isMobile ? (
+						<SidebarTrigger
+							aria-label="Toggle sidebar"
+							className="shrink-0"
+						/>
+					) : null}
 
-					{/* Main content */}
-					<div className="relative z-10 grid h-12 grid-cols-[auto_1fr_auto] items-center gap-4 border-b border-kumo-line px-5">
-						{/* Left section */}
-						{user ? (
-							<motion.div
-								whileTap={{ scale: 0.95 }}
-								transition={{
-									type: 'spring',
-									stiffness: 400,
-									damping: 17,
-								}}
-								className='flex items-center'
-							>
-								<SidebarTrigger className="md:hidden" />
-								{hasMaintenanceMessage && (
+					<div className="min-w-0 flex-1 flex items-center gap-2">
+						{content?.leading ??
+							(!hasPageContent &&
+								hasMaintenanceMessage && (
 									<button
 										type="button"
-										onClick={hasChangeLogs ? () => setIsChangelogOpen(true) : undefined}
+										onClick={
+											hasChangeLogs
+												? () =>
+														setIsChangelogOpen(
+															true,
+														)
+												: undefined
+										}
 										disabled={!hasChangeLogs}
-										className={`flex max-w-full items-center gap-2 rounded-full border border-brand/40 bg-bg-4/80 px-3 ml-4 py-1.5 text-xs text-text-primary shadow-sm backdrop-blur transition-colors hover:bg-brand/10 focus:outline-none focus:ring-2 focus:ring-brand/40 dark:border-brand/30 dark:bg-kumo-elevated/80 md:text-sm${!hasChangeLogs ? ' opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
+										className={`flex max-w-full items-center gap-2 rounded-full border border-brand/40 bg-bg-4/80 px-3 py-1.5 text-xs text-text-primary shadow-sm backdrop-blur hover:bg-brand/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:border-brand/30 dark:bg-kumo-elevated/80 md:text-sm${!hasChangeLogs ? ' opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
 										aria-label="Platform updates"
 									>
 										<AlertCircle className="h-4 w-4 text-kumo-brand" />
-										<span className="truncate max-w-[46ch] md:max-w-[60ch]">{status.globalUserMessage}</span>
+										<span className="truncate max-w-[46ch] md:max-w-[60ch]">
+											{status.globalUserMessage}
+										</span>
 										<ChevronRight className="ml-1 h-4 w-4 text-kumo-brand" />
 									</button>
-								)}
-							</motion.div>
-						) : (
-							<div></div>
+								))}
+					</div>
+
+					<div className="flex items-center justify-end gap-1.5 shrink-0">
+						{content?.trailing}
+						{!authLoading && !user && (
+							<button
+								type="button"
+								onClick={() => showAuthModal()}
+								className="inline-flex h-7 items-center gap-1.5 rounded-md bg-brand px-2.5 text-xs font-medium text-white hover:bg-brand/90"
+							>
+								<SignInIcon className="h-4 w-4" />
+								<span>Sign In</span>
+							</button>
 						)}
-
-
-
-						{/* Right section */}
-						<motion.div
-							initial={{ opacity: 0, x: 10 }}
-							animate={{ opacity: 1, x: 0 }}
-							transition={{ delay: 0.2 }}
-							className="flex flex-wrap items-center justify-end gap-3 justify-self-end"
-						>
-							{/* Disable cost display for now */}
-							{/* {user && (
-							<CostDisplay
-								{...extractUserAnalyticsProps(analytics)}
-								loading={analyticsLoading}
-								variant="inline"
-							/>
-						)} */}
-							{/*{user && (
-								<UsageLimitsBadge
-									onConnect={() => {
-										const url = new URL('/oauth/login', window.location.origin);
-										url.searchParams.set('return_url', window.location.pathname + window.location.search);
-										window.location.href = url.toString();
-									}}
-								/>
-							)}*/}
-							{!user && <AuthButton />}
-						</motion.div>
 					</div>
 				</div>
-			</motion.header>
-			{hasChangeLogs && (
-				<DialogContent className="max-w-xl">
-					<DialogHeader>
-						<DialogTitle>Platform updates</DialogTitle>
-						{status.globalUserMessage && (
-							<DialogDescription className="text-sm text-muted-foreground">
-								{status.globalUserMessage}
-							</DialogDescription>
-						)}
-					</DialogHeader>
-					<ScrollArea className="max-h-[60vh] pr-4">
-						<p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
-							{status.changeLogs}
-						</p>
-					</ScrollArea>
-				</DialogContent>
-			)}
-		</Dialog>
+			</header>
+
+			<Dialog open={isChangelogOpen} onOpenChange={setIsChangelogOpen}>
+				{hasChangeLogs && (
+					<DialogContent className="max-w-xl">
+						<DialogHeader>
+							<DialogTitle>Platform updates</DialogTitle>
+							{status.globalUserMessage && (
+								<DialogDescription className="text-sm text-muted-foreground">
+									{status.globalUserMessage}
+								</DialogDescription>
+							)}
+						</DialogHeader>
+						<ScrollArea className="max-h-[60vh] pr-4">
+							<p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+								{status.changeLogs}
+							</p>
+						</ScrollArea>
+					</DialogContent>
+				)}
+			</Dialog>
+		</>
 	);
 }

--- a/src/components/layout/global-header.tsx
+++ b/src/components/layout/global-header.tsx
@@ -12,7 +12,6 @@ import {
 	DialogTitle,
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { useLocation } from 'react-router';
 import { useAuthModal } from '../auth/AuthModalProvider';
 import { useHeaderContent } from './header-context';
 
@@ -29,7 +28,6 @@ export function GlobalHeader() {
 	const hasChangeLogs = Boolean(
 		status.changeLogs && status.changeLogs.trim().length > 0,
 	);
-	const { pathname } = useLocation();
 	const hasPageContent = Boolean(content?.leading || content?.trailing);
 
 	useEffect(() => {
@@ -40,12 +38,7 @@ export function GlobalHeader() {
 
 	return (
 		<>
-			<header
-				className={cn(
-					'sticky top-0 z-10',
-					pathname !== '/' && 'bg-kumo-base',
-				)}
-			>
+			<header className={cn('sticky top-0 z-10')}>
 				<div className="relative flex h-12 items-center gap-2 border-b border-kumo-line pl-2 pr-3 md:gap-3 md:px-4">
 					{isMobile ? (
 						<SidebarTrigger
@@ -56,29 +49,25 @@ export function GlobalHeader() {
 
 					<div className="min-w-0 flex-1 flex items-center gap-2">
 						{content?.leading ??
-							(!hasPageContent &&
-								hasMaintenanceMessage && (
-									<button
-										type="button"
-										onClick={
-											hasChangeLogs
-												? () =>
-														setIsChangelogOpen(
-															true,
-														)
-												: undefined
-										}
-										disabled={!hasChangeLogs}
-										className={`flex max-w-full items-center gap-2 rounded-full border border-brand/40 bg-bg-4/80 px-3 py-1.5 text-xs text-text-primary shadow-sm backdrop-blur hover:bg-brand/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:border-brand/30 dark:bg-kumo-elevated/80 md:text-sm${!hasChangeLogs ? ' opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
-										aria-label="Platform updates"
-									>
-										<AlertCircle className="h-4 w-4 text-kumo-brand" />
-										<span className="truncate max-w-[46ch] md:max-w-[60ch]">
-											{status.globalUserMessage}
-										</span>
-										<ChevronRight className="ml-1 h-4 w-4 text-kumo-brand" />
-									</button>
-								))}
+							(!hasPageContent && hasMaintenanceMessage && (
+								<button
+									type="button"
+									onClick={
+										hasChangeLogs
+											? () => setIsChangelogOpen(true)
+											: undefined
+									}
+									disabled={!hasChangeLogs}
+									className={`flex max-w-full items-center gap-2 rounded-full border border-brand/40 bg-bg-4/80 px-3 py-1.5 text-xs text-text-primary shadow-sm backdrop-blur hover:bg-brand/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:border-brand/30 dark:bg-kumo-elevated/80 md:text-sm${!hasChangeLogs ? ' opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
+									aria-label="Platform updates"
+								>
+									<AlertCircle className="h-4 w-4 text-kumo-brand" />
+									<span className="truncate max-w-[46ch] md:max-w-[60ch]">
+										{status.globalUserMessage}
+									</span>
+									<ChevronRight className="ml-1 h-4 w-4 text-kumo-brand" />
+								</button>
+							))}
 					</div>
 
 					<div className="flex items-center justify-end gap-1.5 shrink-0">

--- a/src/components/layout/header-context.tsx
+++ b/src/components/layout/header-context.tsx
@@ -1,0 +1,93 @@
+import {
+	createContext,
+	useContext,
+	useLayoutEffect,
+	useRef,
+	useSyncExternalStore,
+	type ReactNode,
+} from 'react';
+
+export type HeaderContent = {
+	leading?: ReactNode;
+	trailing?: ReactNode;
+};
+
+type HeaderStore = {
+	getSnapshot: () => HeaderContent | null;
+	setContent: (content: HeaderContent | null) => void;
+	subscribe: (listener: () => void) => () => void;
+};
+
+function createHeaderStore(): HeaderStore {
+	let content: HeaderContent | null = null;
+	const listeners = new Set<() => void>();
+
+	return {
+		getSnapshot: () => content,
+		setContent: (next) => {
+			if (Object.is(content, next)) return;
+			content = next;
+			listeners.forEach((listener) => listener());
+		},
+		subscribe: (listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+	};
+}
+
+const HeaderStoreContext = createContext<HeaderStore | null>(null);
+
+export function HeaderProvider({ children }: { children: ReactNode }) {
+	const storeRef = useRef<HeaderStore | null>(null);
+	if (!storeRef.current) {
+		storeRef.current = createHeaderStore();
+	}
+
+	return (
+		<HeaderStoreContext.Provider value={storeRef.current}>
+			{children}
+		</HeaderStoreContext.Provider>
+	);
+}
+
+function useHeaderStore() {
+	const store = useContext(HeaderStoreContext);
+	if (!store) {
+		throw new Error('useHeaderStore must be used within HeaderProvider');
+	}
+	return store;
+}
+
+export function useHeaderContent() {
+	const store = useHeaderStore();
+	const content = useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getSnapshot,
+	);
+
+	return {
+		content,
+		setContent: store.setContent,
+	};
+}
+
+/** Registers page-specific header slots for the lifetime of the caller. */
+export function usePageHeader(content: HeaderContent | null) {
+	const store = useHeaderStore();
+	const contentRef = useRef(content);
+	contentRef.current = content;
+
+	useLayoutEffect(() => {
+		store.setContent(contentRef.current);
+	});
+
+	useLayoutEffect(() => {
+		return () => {
+			store.setContent(null);
+		};
+	}, [store]);
+}

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -52,6 +52,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { usePageHeader } from '@/components/layout/header-context';
 import { FileExplorer } from '../chat/components/file-explorer';
 import { PreviewIframe } from '../chat/components/preview-iframe';
 
@@ -362,7 +363,7 @@ export default function AppView() {
 		}
 	};
 
-	const handleToggleVisibility = async () => {
+	const handleToggleVisibility = useCallback(async () => {
 		if (!app || !user || !isOwner) {
 			toast.add({
 				title: 'You can only change visibility of your own apps',
@@ -392,70 +393,13 @@ export default function AppView() {
 				variant: 'error',
 			});
 		}
-	};
+	}, [app, user, isOwner, updateVisibility, toast]);
 
-	const handleDeleteApp = async () => {
-		if (!app) return;
+	const headerContent = useMemo(() => {
+		if (loading || error || !app) return null;
 
-		try {
-			await deleteApp(app.id);
-			toast.add({
-				title: 'App deleted successfully',
-				variant: 'success',
-			});
-			setIsDeleteDialogOpen(false);
-
-			if (window.history.length > 1) {
-				window.history.back();
-			} else {
-				navigate('/apps');
-			}
-		} catch (error) {
-			console.error('Error deleting app:', error);
-			toast.add({
-				title: 'An unexpected error occurred while deleting the app',
-				variant: 'error',
-			});
-		}
-	};
-
-	if (loading) {
-		return <AppLoadingSkeleton />;
-	}
-
-	if (error || !app) {
-		return (
-			<div className="size-full flex items-center justify-center p-4">
-				<LayerCard className="max-w-md w-full px-5 py-6">
-					<div className="text-center grid gap-4">
-						<div className="grid gap-1.5">
-							<h2 className="text-lg font-semibold text-text-primary">
-								App not found
-							</h2>
-							<p className="text-sm text-kumo-subtle">
-								{error ||
-									"The app you're looking for doesn't exist."}
-							</p>
-						</div>
-						<div className="flex justify-center">
-							<Button
-								variant="secondary"
-								size="sm"
-								icon={<ChevronLeft className="h-4 w-4" />}
-								onClick={() => navigate('/apps')}
-							>
-								Back to apps
-							</Button>
-						</div>
-					</div>
-				</LayerCard>
-			</div>
-		);
-	}
-
-	return (
-		<div className="size-full flex flex-col min-h-0">
-			<header className="h-12 shrink-0 flex items-center gap-3 px-4 border-b">
+		return {
+			leading: (
 				<div className="min-w-0 flex-1 flex items-center gap-2">
 					<h1
 						className="text-sm font-semibold truncate min-w-0"
@@ -477,8 +421,9 @@ export default function AppView() {
 						</span>
 					</Badge>
 				</div>
-
-				<div className="flex items-center gap-1.5 shrink-0">
+			),
+			trailing: (
+				<>
 					{isOwner && (
 						<Button
 							variant="secondary"
@@ -581,9 +526,82 @@ export default function AppView() {
 							</DropdownMenu>
 						</>
 					)}
-				</div>
-			</header>
+				</>
+			),
+		};
+	}, [
+		loading,
+		error,
+		app,
+		isOwner,
+		isUpdatingVisibility,
+		handleToggleVisibility,
+		navigate,
+	]);
 
+	usePageHeader(headerContent);
+
+	const handleDeleteApp = async () => {
+		if (!app) return;
+
+		try {
+			await deleteApp(app.id);
+			toast.add({
+				title: 'App deleted successfully',
+				variant: 'success',
+			});
+			setIsDeleteDialogOpen(false);
+
+			if (window.history.length > 1) {
+				window.history.back();
+			} else {
+				navigate('/apps');
+			}
+		} catch (error) {
+			console.error('Error deleting app:', error);
+			toast.add({
+				title: 'An unexpected error occurred while deleting the app',
+				variant: 'error',
+			});
+		}
+	};
+
+	if (loading) {
+		return <AppLoadingSkeleton />;
+	}
+
+	if (error || !app) {
+		return (
+			<div className="size-full flex items-center justify-center p-4">
+				<LayerCard className="max-w-md w-full px-5 py-6">
+					<div className="text-center grid gap-4">
+						<div className="grid gap-1.5">
+							<h2 className="text-lg font-semibold text-text-primary">
+								App not found
+							</h2>
+							<p className="text-sm text-kumo-subtle">
+								{error ||
+									"The app you're looking for doesn't exist."}
+							</p>
+						</div>
+						<div className="flex justify-center">
+							<Button
+								variant="secondary"
+								size="sm"
+								icon={<ChevronLeft className="h-4 w-4" />}
+								onClick={() => navigate('/apps')}
+							>
+								Back to apps
+							</Button>
+						</div>
+					</div>
+				</LayerCard>
+			</div>
+		);
+	}
+
+	return (
+		<div className="size-full flex flex-col min-h-0">
 			<div className="shrink-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between px-4 py-2 border-b">
 				<Tabs
 					value={activeTab}

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -85,6 +85,7 @@ import {
 import { queryKeys } from '@/lib/query-keys';
 import { ApiError } from '@/lib/api-client';
 import { capitalizeFirstLetter } from '@/lib/utils';
+import { usePageHeader } from '@/components/layout/header-context';
 
 const isPhasicBlueprint = (
 	blueprint?: BlueprintType | null,
@@ -339,6 +340,127 @@ export default function Chat() {
 
 	const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
 	const [isGitCloneModalOpen, setIsGitCloneModalOpen] = useState(false);
+
+	const headerTitle = blueprint?.title || appTitle;
+	const showHeader = Boolean(
+		headerTitle || chatId || appLoading || app?.visibility,
+	);
+
+	const headerContent = useMemo(() => {
+		if (!showHeader) return null;
+
+		if (appLoading) {
+			return {
+				leading: (
+					<div className="flex items-center gap-2 text-kumo-subtle text-sm">
+						<LoaderCircle className="size-4 animate-spin" />
+						Loading app...
+					</div>
+				),
+			};
+		}
+
+		return {
+			leading: (
+				<div className="min-w-0 flex-1 flex items-center gap-2">
+					<div
+						className="text-sm font-semibold truncate min-w-0"
+						title={headerTitle || undefined}
+					>
+						{headerTitle}
+					</div>
+					{app?.visibility && (
+						<Badge
+							className="shrink-0"
+							variant={
+								app.visibility === 'private'
+									? 'secondary'
+									: 'success'
+							}
+						>
+							<span className="inline-flex items-center gap-1">
+								<Globe className="h-3 w-3" weight="duotone" />
+								{capitalizeFirstLetter(app.visibility)}
+							</span>
+						</Badge>
+					)}
+				</div>
+			),
+			trailing: (
+				<>
+					{isOwner && app && (
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={handleToggleVisibility}
+							disabled={isUpdatingVisibility}
+							loading={isUpdatingVisibility}
+							icon={
+								app.visibility === 'private' ? (
+									<LockOpen
+										className="size-3.5"
+										weight="duotone"
+									/>
+								) : (
+									<Lock
+										className="size-3.5"
+										weight="duotone"
+									/>
+								)
+							}
+						>
+							{app.visibility === 'private'
+								? 'Make public'
+								: 'Make private'}
+						</Button>
+					)}
+					{app && (
+						<DropdownMenu>
+							<DropdownMenu.Trigger
+								render={
+									<Button
+										variant="secondary"
+										size="sm"
+										shape="square"
+										aria-label="More actions"
+										icon={<DotsThree className="h-4 w-4" />}
+									/>
+								}
+							/>
+							<DropdownMenu.Content align="end">
+								<DropdownMenu.Item
+									icon={BookmarkSimpleIcon}
+									onClick={() => {
+										void handleFavorite();
+									}}
+								>
+									{isFavorited ? 'Bookmarked' : 'Bookmark'}
+								</DropdownMenu.Item>
+								<DropdownMenu.Item
+									icon={GitBranch}
+									onClick={() => setIsGitCloneModalOpen(true)}
+								>
+									Clone
+								</DropdownMenu.Item>
+							</DropdownMenu.Content>
+						</DropdownMenu>
+					)}
+				</>
+			),
+		};
+	}, [
+		showHeader,
+		appLoading,
+		headerTitle,
+		app,
+		isOwner,
+		isUpdatingVisibility,
+		handleToggleVisibility,
+		handleFavorite,
+		isFavorited,
+	]);
+
+	usePageHeader(headerContent);
 
 	// Usage limits state
 	const { data: limitsData, loading: limitsLoading } = useLimitsContext();
@@ -968,122 +1090,6 @@ export default function Chat() {
 	return (
 		<RollbackContext.Provider value={rollbackHandler}>
 			<div className="size-full flex flex-col min-h-0 text-text-primary">
-				{(blueprint?.title || appTitle || chatId || appLoading) && (
-					<div className="h-12 shrink-0 flex items-center gap-3 px-4 border-b">
-						{appLoading ? (
-							<div className="flex items-center gap-2 text-kumo-subtle text-sm">
-								<LoaderCircle className="size-4 animate-spin" />
-								Loading app...
-							</div>
-						) : (
-							<>
-								<div className="min-w-0 flex-1 flex items-center gap-2">
-									<div
-										className="text-sm font-semibold truncate min-w-0"
-										title={
-											blueprint?.title ||
-											appTitle ||
-											undefined
-										}
-									>
-										{blueprint?.title || appTitle}
-									</div>
-									{app?.visibility && (
-										<Badge
-											className="shrink-0"
-											variant={
-												app.visibility === 'private'
-													? 'secondary'
-													: 'success'
-											}
-										>
-											<span className="inline-flex items-center gap-1">
-												<Globe
-													className="h-3 w-3"
-													weight="duotone"
-												/>
-												{capitalizeFirstLetter(
-													app.visibility,
-												)}
-											</span>
-										</Badge>
-									)}
-								</div>
-								<div className="flex items-center gap-1.5 shrink-0">
-									{isOwner && app && (
-										<Button
-											variant={
-												app.visibility === 'private'
-													? 'primary'
-													: 'secondary'
-											}
-											size="sm"
-											onClick={handleToggleVisibility}
-											disabled={isUpdatingVisibility}
-											loading={isUpdatingVisibility}
-											icon={
-												app.visibility === 'private' ? (
-													<LockOpen
-														className="size-3.5"
-														weight="duotone"
-													/>
-												) : (
-													<Lock
-														className="size-3.5"
-														weight="duotone"
-													/>
-												)
-											}
-										>
-											{app.visibility === 'private'
-												? 'Publish'
-												: 'Unpublish'}
-										</Button>
-									)}
-									{app && (
-										<DropdownMenu>
-											<DropdownMenu.Trigger
-												render={
-													<Button
-														variant="secondary"
-														size="sm"
-														shape="square"
-														aria-label="More actions"
-														icon={
-															<DotsThree className="h-4 w-4" />
-														}
-													/>
-												}
-											/>
-											<DropdownMenu.Content align="end">
-												<DropdownMenu.Item
-													icon={BookmarkSimpleIcon}
-													onClick={() => {
-														void handleFavorite();
-													}}
-												>
-													{isFavorited
-														? 'Bookmarked'
-														: 'Bookmark'}
-												</DropdownMenu.Item>
-												<DropdownMenu.Item
-													icon={GitBranch}
-													onClick={() =>
-														setIsGitCloneModalOpen(
-															true,
-														)
-													}
-												>
-													Clone
-												</DropdownMenu.Item>
-											</DropdownMenu.Content>
-										</DropdownMenu>
-									)}
-								</div>
-							</>
-						)}
-					</div>
-				)}
 				<div className="flex-1 flex min-h-0 overflow-hidden justify-center">
 					<motion.div
 						layout="position"


### PR DESCRIPTION
- Integrates a new `GlobalHeader` across the app layout so the sidebar no
  longer owns the top-level header.
- Adds `HeaderProvider` + `usePageHeader` so routes (`AppView`, `Chat`) can
  register their own header content.
- Updates `AppSidebar` to use the latest Kumo 2.9.0 sidebar composition API
  (`Sidebar.Header`, `Sidebar.Content`, `Sidebar.Group`, `Sidebar.Collapsible`,
  etc.).
- Upgrades `@cloudflare/kumo` to `^2.9.0` and updates the lockfile.
- Moves the sign-in CTA into `GlobalHeader`; `AuthButton` now only renders for
  authenticated users.

Test plan: `bun run typecheck`, `bun run lint`, `bun run test`, and manual
verification of the sidebar/header UI in local dev.
