### PR TITLE
feat(ui): redesign profile page and add orange gradient button

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://cdnjs.cloudflare.com https://cdn.tailwindcss.com https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' wss: ws: http: https:; frame-src 'self' http://*.localhost:* https://*;" />
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Gloria+Hallelujah&family=Caveat:wght@600&display=swap" rel="stylesheet">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://cdnjs.cloudflare.com https://cdn.tailwindcss.com https://esm.sh; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self'; img-src 'self' data: https:; connect-src 'self' wss: ws: http: https:; frame-src 'self' http://*.localhost:* https://*;" />
 		<title>Build</title>
 		<meta name="description" content="Ship your app from idea to v1!" />
 		<script>

--- a/src/components/auth/auth-button.tsx
+++ b/src/components/auth/auth-button.tsx
@@ -7,13 +7,14 @@ import { Loader2, LucideGlobeLock } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { cn, Button, DropdownMenu } from '@cloudflare/kumo';
 import { useAuth } from '../../contexts/auth-context';
+import { getInitials } from '@/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { Skeleton } from '../ui/skeleton';
 import {
 	useUsageLimitsBadgeState,
 	type UsageLimitsBadgeState,
 } from '../usage-limits-badge';
-import { GearIcon, SignOutIcon } from '@phosphor-icons/react';
+import { GearIcon, SignOutIcon, UserIcon } from '@phosphor-icons/react';
 
 interface AuthButtonProps {
 	className?: string;
@@ -64,17 +65,7 @@ export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
 		return null;
 	}
 
-	const getInitials = () => {
-		if (user.displayName) {
-			return user.displayName
-				.split(' ')
-				.map((n) => n[0])
-				.join('')
-				.toUpperCase()
-				.slice(0, 2);
-		}
-		return user.email.charAt(0).toUpperCase();
-	};
+	const initials = getInitials(user.displayName, user.email);
 
 	return (
 		<DropdownMenu>
@@ -95,7 +86,7 @@ export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
 									alt={user.displayName || user.email}
 								/>
 								<AvatarFallback className="bg-kumo-elevated text-xs font-semibold text-kumo-default">
-									{getInitials()}
+									{initials}
 								</AvatarFallback>
 							</Avatar>
 							<span className="min-w-0 flex-1 flex-col group-data-[state=collapsed]/sidebar:hidden">
@@ -131,7 +122,7 @@ export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
 									alt={user.displayName || user.email}
 								/>
 								<AvatarFallback className="bg-kumo-elevated font-semibold text-kumo-default">
-									{getInitials()}
+									{initials}
 								</AvatarFallback>
 							</Avatar>
 						</Button>
@@ -194,6 +185,12 @@ export function AuthButton({ className, display = 'icon' }: AuthButtonProps) {
 								Manage AI Gateway
 							</DropdownMenu.Item>
 						)}
+					<DropdownMenu.Item
+						onClick={() => navigate('/profile')}
+						icon={UserIcon}
+					>
+						Profile
+					</DropdownMenu.Item>
 					<DropdownMenu.Item
 						onClick={() => navigate('/settings')}
 						icon={GearIcon}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
 import { useAuth } from '@/contexts/auth-context';
 import { useApps, useFavoriteApps, useRecentApps } from '@/hooks/use-apps';
 import { AppActionsDropdown } from '@/components/shared/AppActionsDropdown';
+import { OrangeButton } from '@/components/shared/OrangeButton';
 import { AuthButton } from '@/components/auth/auth-button';
 import { useUsageLimitsBadgeState } from '@/components/usage-limits-badge';
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -288,14 +289,18 @@ export function AppSidebar() {
 					{isCollapsed ? (
 						<div className="flex flex-col items-center gap-1">
 							{pathname !== '/' && (
-								<Button
+								<OrangeButton
 									shape="square"
-									size="base"
 									aria-label="New build"
 									title="New build"
 									onClick={() => navigate('/')}
-									className="bg-brand text-white shadow-none ring-0 hover:bg-brand/80"
-									icon={<PlusIcon className="size-4" weight="bold" />}
+									className="size-8!"
+									icon={
+										<PlusIcon
+											className="size-4"
+											weight="bold"
+										/>
+									}
 								/>
 							)}
 							<Button
@@ -321,14 +326,20 @@ export function AppSidebar() {
 						<div className="flex flex-col gap-1.5">
 							<Sidebar.Menu className="gap-y-1.5">
 								{pathname !== '/' && (
-									<Sidebar.MenuButton
-										icon={PlusIcon}
-										className="bg-brand text-white hover:bg-brand/80"
-										tooltip="New build"
+									<OrangeButton
+										fullWidth
+										icon={
+											<PlusIcon
+												className="size-4"
+												weight="bold"
+											/>
+										}
+										title="New build"
 										onClick={() => navigate('/')}
+										className="h-8! text-sm"
 									>
 										New build
-									</Sidebar.MenuButton>
+									</OrangeButton>
 								)}
 
 								<Sidebar.MenuButton
@@ -558,29 +569,31 @@ export function AppSidebar() {
 			<Sidebar.Footer className="h-auto p-3">
 				<div className="flex w-full min-w-0 flex-col gap-2">
 					{showCloudflareCta && (
-						<button
-							type="button"
+						<OrangeButton
 							onClick={handleCloudflareCta}
 							aria-label={cloudflareCtaLabel}
 							title={cloudflareCtaLabel}
+							fullWidth={!isCollapsed}
+							shape={isCollapsed ? 'square' : 'base'}
 							className={cn(
-								'inline-flex items-center rounded-lg bg-brand text-sm font-medium text-white hover:bg-brand/90',
 								isCollapsed
-									? 'size-9 shrink-0 justify-center self-center'
-									: 'h-9 w-full justify-start gap-3 px-3',
+									? 'size-8! shrink-0 self-center'
+									: 'h-8! gap-2 text-sm',
 							)}
+							icon={
+								<CloudflareLogo
+									variant="glyph"
+									color="white"
+									className="size-5 shrink-0"
+								/>
+							}
 						>
-							<CloudflareLogo
-								variant="glyph"
-								color="white"
-								className="size-6 shrink-0"
-							/>
-							{!isCollapsed && (
+							{!isCollapsed ? (
 								<span className="truncate">
 									{cloudflareCtaLabel}
 								</span>
-							)}
-						</button>
+							) : null}
+						</OrangeButton>
 					)}
 					<div
 						className={cn(

--- a/src/components/layout/global-header.tsx
+++ b/src/components/layout/global-header.tsx
@@ -12,6 +12,7 @@ import {
 	DialogTitle,
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { OrangeButton } from '@/components/shared/OrangeButton';
 import { useAuthModal } from '../auth/AuthModalProvider';
 import { useHeaderContent } from './header-context';
 
@@ -73,14 +74,13 @@ export function GlobalHeader() {
 					<div className="flex items-center justify-end gap-1.5 shrink-0">
 						{content?.trailing}
 						{!authLoading && !user && (
-							<button
-								type="button"
+							<OrangeButton
+								size="sm"
 								onClick={() => showAuthModal()}
-								className="inline-flex h-7 items-center gap-1.5 rounded-md bg-brand px-2.5 text-xs font-medium text-white hover:bg-brand/90"
+								icon={<SignInIcon className="size-4" />}
 							>
-								<SignInIcon className="h-4 w-4" />
-								<span>Sign In</span>
-							</button>
+								Sign In
+							</OrangeButton>
 						)}
 					</div>
 				</div>

--- a/src/components/prompt-box.tsx
+++ b/src/components/prompt-box.tsx
@@ -4,6 +4,7 @@ import { cn } from '@cloudflare/kumo';
 import { ImageAttachmentPreview } from '@/components/image-attachment-preview';
 import { ImageUploadButton } from '@/components/image-upload-button';
 import { CreditsBanner } from '@/components/credits-banner';
+import { OrangeButton } from '@/components/shared/OrangeButton';
 import { useTypewriterPlaceholder } from '@/hooks/use-typewriter-placeholder';
 import type { ImageAttachment } from '@/api-types';
 import { type UsageSummary } from '@/hooks/use-limits';
@@ -194,19 +195,23 @@ export function PromptBox({
 								/>
 								<div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1">
 									{rightActions}
-									<button
+									<OrangeButton
 										type="submit"
+										shape="square"
+										size="sm"
 										disabled={
 											!value.trim() ||
 											disabled ||
 											submitDisabled
 										}
-										className="p-1.5 rounded-md bg-brand/90 hover:bg-brand/80 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-transparent text-white disabled:text-text-primary transition-colors"
-									>
-										{submitIcon ?? (
-											<ArrowRightIcon className="size-4" />
-										)}
-									</button>
+										aria-label="Send message"
+										title="Send message"
+										icon={
+											submitIcon ?? (
+												<ArrowRightIcon className="size-4" />
+											)
+										}
+									/>
 								</div>
 							</div>
 						</form>
@@ -302,15 +307,22 @@ export function PromptBox({
 								onFilesSelected={onAddImages}
 								disabled={disabled || isProcessing}
 							/>
-							<button
+							<OrangeButton
 								type="submit"
+								shape="square"
+								size="sm"
 								disabled={
 									!value.trim() || disabled || submitDisabled
 								}
-								className="bg-brand text-white p-1 rounded-md *:size-5 transition-all duration-200 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
-							>
-								{submitIcon ?? <ArrowRightIcon />}
-							</button>
+								aria-label="Send message"
+								title="Send message"
+								className="size-7!"
+								icon={
+									submitIcon ?? (
+										<ArrowRightIcon className="size-5" />
+									)
+								}
+							/>
 						</div>
 					</div>
 				</form>

--- a/src/components/shared/OrangeButton.tsx
+++ b/src/components/shared/OrangeButton.tsx
@@ -1,0 +1,96 @@
+import type { CSSProperties, MouseEventHandler, ReactNode } from 'react';
+import { Button, cn } from '@cloudflare/kumo';
+
+type OrangeButtonSize = 'xs' | 'sm' | 'base' | 'lg';
+type OrangeButtonShape = 'base' | 'square' | 'circle';
+
+export interface OrangeButtonProps {
+	children?: ReactNode;
+	className?: string;
+	disabled?: boolean;
+	/** Stretch to fill the parent width (e.g. sidebar CTAs). */
+	fullWidth?: boolean;
+	icon?: ReactNode;
+	id?: string;
+	loading?: boolean;
+	onClick?: MouseEventHandler<HTMLButtonElement>;
+	shape?: OrangeButtonShape;
+	size?: OrangeButtonSize;
+	type?: 'button' | 'submit' | 'reset';
+	/** Tooltip content; also used as accessible name for icon-only buttons. */
+	title?: string;
+	'aria-label'?: string;
+	'aria-labelledby'?: string;
+}
+
+/** Mirrors Kumo primary emphasis tokens, keyed off brand orange instead of kumo-brand blue. */
+const orangeEmphasisStyle = {
+	'--kumo-button-emphasis-ring':
+		'color-mix(in oklch, var(--color-brand), black 10%)',
+	'--kumo-button-emphasis-bg':
+		'color-mix(in oklch, var(--color-brand), white 30%)',
+	'--kumo-button-emphasis-gradient-start':
+		'color-mix(in oklch, var(--color-brand), white 15%)',
+	'--kumo-button-emphasis-gradient-end': 'var(--color-brand)',
+} as CSSProperties;
+
+export function OrangeButton({
+	children,
+	className,
+	disabled,
+	fullWidth = false,
+	icon,
+	id,
+	loading,
+	onClick,
+	shape = 'base',
+	size = 'base',
+	type = 'button',
+	title,
+	'aria-label': ariaLabel,
+	'aria-labelledby': ariaLabelledBy,
+}: OrangeButtonProps) {
+	const mergedClassName = cn(fullWidth && 'w-full justify-start', className);
+
+	if (shape === 'square' || shape === 'circle') {
+		return (
+			<Button
+				type={type}
+				shape={shape}
+				size={size}
+				variant="primary"
+				className={mergedClassName}
+				style={orangeEmphasisStyle}
+				disabled={disabled}
+				icon={icon}
+				id={id}
+				loading={loading}
+				onClick={onClick}
+				title={title ?? ariaLabel ?? ''}
+				aria-label={ariaLabel}
+				aria-labelledby={ariaLabelledBy}
+			/>
+		);
+	}
+
+	return (
+		<Button
+			type={type}
+			shape="base"
+			size={size}
+			variant="primary"
+			className={mergedClassName}
+			style={orangeEmphasisStyle}
+			disabled={disabled}
+			icon={icon}
+			id={id}
+			loading={loading}
+			onClick={onClick}
+			title={title}
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabelledBy}
+		>
+			{children}
+		</Button>
+	);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -339,6 +339,18 @@
 	}
 }
 
+/* Mirrors OrangeButton / Kumo primary emphasis gradient on text fill. */
+@utility text-brand-emphasis {
+	background-image: linear-gradient(
+		to bottom,
+		color-mix(in oklch, var(--color-brand), white 15%),
+		var(--color-brand)
+	);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+}
+
 @property --spin-angle {
 	syntax: '<angle>';
 	initial-value: 0deg;

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -685,7 +685,7 @@ class ApiClient {
 	 * Get user statistics
 	 */
 	async getUserStats(): Promise<ApiResponse<UserStatsData>> {
-		return this.request<UserStatsData>('/api/stats/user');
+		return this.request<UserStatsData>('/api/stats');
 	}
 
 	/**

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { getRegistrableDomain } from './utils';
+import { getInitials, getRegistrableDomain } from './utils';
+
+describe('getInitials', () => {
+	it('uses first letters of first and last name', () => {
+		expect(getInitials('Jane Doe')).toBe('JD');
+		expect(getInitials('Ada Lovelace Byron')).toBe('AL');
+	});
+
+	it('falls back to email initial, then default', () => {
+		expect(getInitials(undefined, 'user@example.com')).toBe('U');
+		expect(getInitials(null, null)).toBe('?');
+		expect(getInitials('  ', '  ', 'X')).toBe('X');
+	});
+});
 
 // Note: `isCrossSitePreview` and `isAppleWebKitBrowser` depend on `window`/
 // `navigator` and are exercised in the browser, not this workers-pool harness.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,27 @@ export function capitalizeFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+/** First letters of first/last name from displayName, else email initial, else fallback. */
+export function getInitials(
+  displayName?: string | null,
+  email?: string | null,
+  fallback = '?',
+): string {
+  if (displayName?.trim()) {
+    return displayName
+      .trim()
+      .split(/\s+/)
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  }
+  if (email?.trim()) {
+    return email.trim().charAt(0).toUpperCase();
+  }
+  return fallback;
+}
+
 /**
  * Detect Apple/WebKit browsers subject to Intelligent Tracking Prevention
  * (ITP), which blocks third-party cookies for an origin embedded in a

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -567,12 +567,18 @@ export default function AppView() {
 	};
 
 	if (loading) {
-		return <AppLoadingSkeleton />;
+		return (
+			<>
+				<title>Loading - Build</title>
+				<AppLoadingSkeleton />
+			</>
+		);
 	}
 
 	if (error || !app) {
 		return (
 			<div className="size-full flex items-center justify-center p-4">
+				<title>App not found - Build</title>
 				<LayerCard className="max-w-md w-full px-5 py-6">
 					<div className="text-center grid gap-4">
 						<div className="grid gap-1.5">
@@ -602,6 +608,7 @@ export default function AppView() {
 
 	return (
 		<div className="size-full flex flex-col min-h-0">
+			<title>{app.title ? `${app.title} - Build` : 'App - Build'}</title>
 			<div className="shrink-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between px-4 py-2 border-b">
 				<Tabs
 					value={activeTab}

--- a/src/routes/apps/index.tsx
+++ b/src/routes/apps/index.tsx
@@ -65,6 +65,7 @@ export default function AppsPage() {
 
 	return (
 		<div className="size-full">
+			<title>My Apps - Build</title>
 			<div className="container mx-auto px-4 py-8">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -1058,6 +1058,7 @@ export default function Chat() {
 	if (awaitingStartConfirmation) {
 		return (
 			<div className="size-full flex items-center justify-center p-6 text-text-primary">
+				<title>Start building - Build</title>
 				<div className="max-w-lg w-full flex flex-col gap-4 rounded-xl border bg-kumo-elevated p-6">
 					<h1 className="text-lg font-medium">
 						Start building this app?
@@ -1089,6 +1090,9 @@ export default function Chat() {
 
 	return (
 		<RollbackContext.Provider value={rollbackHandler}>
+			<title>
+				{headerTitle ? `${headerTitle} - Build` : 'Chat - Build'}
+			</title>
 			<div className="size-full flex flex-col min-h-0 text-text-primary">
 				<div className="flex-1 flex min-h-0 overflow-hidden justify-center">
 					<motion.div

--- a/src/routes/discover/index.tsx
+++ b/src/routes/discover/index.tsx
@@ -67,6 +67,7 @@ export default function DiscoverPage() {
 
 	return (
 		<div className="size-full">
+			<title>Discover - Build</title>
 			<div className="container max-w-6xl mx-auto px-4 py-8">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}

--- a/src/routes/discover/index.tsx
+++ b/src/routes/discover/index.tsx
@@ -75,10 +75,10 @@ export default function DiscoverPage() {
 				>
 					{/* Header */}
 					<div className="mb-8 mt-6">
-						<h1 className="flex gap-2 text-6xl font-funky-mono font-bold mb-3 text-brand/90">
+						<h1 className="flex gap-2 text-6xl font-funky-mono font-bold mb-3 text-brand-emphasis">
 							<GlobeIcon
 								weight="duotone"
-								className="-rotate-30"
+								className="-rotate-30 text-brand"
 							/>
 							Discover
 						</h1>

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -184,6 +184,7 @@ export default function Home() {
 
 	return (
 		<div className="relative flex flex-col items-center w-full min-h-full">
+			<title>Build</title>
 			<div className="home-atmosphere" aria-hidden>
 				<div className="home-atmosphere__spotlight" />
 			</div>

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -204,7 +204,7 @@ export default function Home() {
 						<div className="mb-6 sm:mb-7 grid gap-2">
 							<h1 className="w-full text-center text-[clamp(1.75rem,4.5vw,2.5rem)] font-semibold leading-[1.12] text-kumo-strong/80 z-20">
 								What should we{' '}
-								<span className="font-funky-mono text-[1.1em] tracking-tighter uppercase text-brand">
+								<span className="font-funky-mono font-bold text-[1.1em] tracking-tighter uppercase text-brand-emphasis">
 									build
 								</span>{' '}
 								today?

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,35 +1,69 @@
 import React from 'react';
 import { useAuth } from '@/contexts/auth-context';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, cn } from '@cloudflare/kumo';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import {
-	Mail,
-	Calendar,
-	Shield,
-	Activity,
-	Code2,
+	Badge,
+	Button,
+	cn,
+	Empty,
+	Input,
+	InputArea,
+	LayerCard,
+	Loader,
+	Tabs,
+	Text,
+} from '@cloudflare/kumo';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+	CalendarBlank,
+	Code,
+	EnvelopeSimple,
+	Eye,
+	Gear,
+	Globe,
+	GithubLogo,
+	Lightning,
+	PencilSimple,
+	Pulse,
+	ShieldCheck,
 	Star,
 	Trophy,
-	Settings,
-	Edit3,
-	Save,
 	X,
-	Globe,
-	Zap,
-} from 'lucide-react';
+} from '@phosphor-icons/react';
 import { useNavigate } from 'react-router';
-import { capitalizeFirstLetter } from '@/lib/utils';
+import { capitalizeFirstLetter, getInitials } from '@/lib/utils';
+import { formatNumber } from '@/utils/analytics';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { useUserStats, useUserActivity } from '@/hooks/use-stats';
 import { useUpdateProfile } from '@/hooks/use-profile';
 import { useApps } from '@/hooks/use-apps';
+
+const STATS = [
+	{
+		key: 'appCount' as const,
+		label: 'Total apps',
+		icon: Code,
+		iconClass: 'text-kumo-brand',
+	},
+	{
+		key: 'publicAppCount' as const,
+		label: 'Public apps',
+		icon: Globe,
+		iconClass: 'text-teal-500',
+	},
+	{
+		key: 'totalViewsReceived' as const,
+		label: 'Total views',
+		icon: Eye,
+		iconClass: 'text-purple-500',
+	},
+	{
+		key: 'totalLikesReceived' as const,
+		label: 'Total likes',
+		icon: Star,
+		iconClass: 'text-amber-500',
+	},
+] as const;
 
 export default function Profile() {
 	const { user } = useAuth();
@@ -62,8 +96,12 @@ export default function Profile() {
 	const { mutateAsync: saveProfile, isPending: isSaving } =
 		useUpdateProfile();
 
-	// Transform achievements from stats
 	const achievements = stats?.achievements || [];
+
+	const handleEdit = () => {
+		setActiveTab('about');
+		setIsEditing(true);
+	};
 
 	const handleSave = async () => {
 		if (isSaving) return;
@@ -95,161 +133,144 @@ export default function Profile() {
 		setIsEditing(false);
 	};
 
+	const handleTabChange = (value: string) => {
+		setActiveTab(value);
+		if (value !== 'about' && isEditing) {
+			handleCancel();
+		}
+	};
+
+	const initials = getInitials(user?.displayName, user?.email);
+
 	return (
-		<div className="min-h-screen bg-kumo-base">
-			{/* Profile Header */}
-			<div className="container mx-auto px-4 py-8">
-				<div className="pb-8">
-					<div className="flex flex-col md:flex-row items-center gap-6">
-						<Avatar className="h-24 w-24 ring-4 ring-background shadow-xl">
-							<AvatarImage src={user?.avatarUrl} />
-							<AvatarFallback className="text-2xl bg-gradient-to-br from-brand-primary to-brand-light text-white">
-								{user?.displayName?.charAt(0).toUpperCase() ||
-									user?.email?.charAt(0).toUpperCase() ||
-									'?'}
-							</AvatarFallback>
-						</Avatar>
+		<div className="min-h-screen">
+			<main className="container mx-auto max-w-4xl px-4 py-12 pb-24">
+				{/* Header */}
+				<div className="mb-10 flex flex-col items-center gap-6 sm:flex-row sm:items-start">
+					<Avatar className="size-20 ring-2 ring-kumo-line shadow-md sm:size-24">
+						<AvatarImage src={user?.avatarUrl} />
+						<AvatarFallback className="bg-kumo-base text-3xl font-semibold">
+							{initials}
+						</AvatarFallback>
+					</Avatar>
 
-						<div className="flex-1 text-center md:text-left">
-							<div className="flex flex-col md:flex-row items-center gap-4 mb-2">
-								<h1 className="text-3xl font-bold">
-									{user?.displayName}
-								</h1>
-								<div className="flex items-center gap-2">
-									<Badge
-										variant="secondary"
-										className="gap-1"
-									>
-										{user?.provider === 'github' ? (
-											<svg
-												className="h-3 w-3"
-												viewBox="0 0 24 24"
-												fill="currentColor"
-											>
-												<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-											</svg>
-										) : (
-											<Globe className="h-3 w-3" />
-										)}
-										{capitalizeFirstLetter(
-											user?.provider ?? '',
-										)}
-									</Badge>
-									{user?.emailVerified && (
-										<Badge
-											variant="secondary"
-											className="gap-1"
-										>
-											<Shield className="h-3 w-3" />
-											Verified
-										</Badge>
+					<div className="min-w-0 flex-1 text-center sm:text-left">
+						<div className="mb-1.5 flex flex-col items-center gap-2 sm:flex-row sm:flex-wrap">
+							<h1 className="font-funky-mono text-2xl font-semibold text-kumo-strong">
+								{user?.displayName || 'Your profile'}
+							</h1>
+							<div className="flex flex-wrap items-center justify-center gap-1.5">
+								<Badge variant="secondary" className="gap-1">
+									{user?.provider === 'github' ? (
+										<GithubLogo
+											className="size-3"
+											weight="fill"
+										/>
+									) : (
+										<Globe className="size-3" />
 									)}
-								</div>
+									{capitalizeFirstLetter(
+										user?.provider ?? '',
+									)}
+								</Badge>
+								{user?.emailVerified && (
+									<Badge variant="success" className="gap-1">
+										<ShieldCheck
+											className="size-3"
+											weight="fill"
+										/>
+										Verified
+									</Badge>
+								)}
 							</div>
-							<p className="text-kumo-subtle mb-1">
-								{user?.email}
+						</div>
+						<Text variant="secondary" size="sm">
+							{user?.email}
+						</Text>
+						{user?.bio && !isEditing && (
+							<p className="mt-2 max-w-xl text-sm text-kumo-default">
+								{user.bio}
 							</p>
-							{user?.bio && (
-								<p className="text-sm max-w-2xl">{user.bio}</p>
-							)}
-						</div>
+						)}
+					</div>
 
-						<div className="flex gap-2">
-							{isEditing ? (
-								<>
-									<Button
-										onClick={handleSave}
-										size="sm"
-										disabled={isSaving}
-									>
-										<Save className="mr-2 h-4 w-4" />
-										{isSaving
-											? 'Saving...'
-											: 'Save Changes'}
-									</Button>
-									<Button
-										variant="outline"
-										onClick={handleCancel}
-										size="sm"
-									>
-										<X className="mr-2 h-4 w-4" />
-										Cancel
-									</Button>
-								</>
-							) : (
-								<>
-									<Button
-										variant="outline"
-										onClick={() => setIsEditing(true)}
-										size="sm"
-									>
-										<Edit3 className="mr-2 h-4 w-4" />
-										Edit Profile
-									</Button>
-									<Button
-										variant="outline"
-										onClick={() => navigate('/settings')}
-										size="sm"
-									>
-										<Settings className="mr-2 h-4 w-4" />
-										Settings
-									</Button>
-								</>
-							)}
-						</div>
+					<div className="flex shrink-0 gap-2">
+						{isEditing ? (
+							<>
+								<Button
+									variant="primary"
+									size="sm"
+									onClick={handleSave}
+									loading={isSaving}
+								>
+									Save changes
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleCancel}
+									icon={<X className="size-4" />}
+								>
+									Cancel
+								</Button>
+							</>
+						) : (
+							<>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={handleEdit}
+									icon={<PencilSimple className="size-4" />}
+								>
+									Edit profile
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => navigate('/settings')}
+									icon={<Gear className="size-4" />}
+								>
+									Settings
+								</Button>
+							</>
+						)}
 					</div>
 				</div>
-			</div>
 
-			<div className="container mx-auto px-4 py-8">
-				{/* Stats Overview */}
-				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
-					<Card className="text-center hover:shadow-lg hover:scale-[1.02] transition-all dark:bg-bg-4/50">
-						<CardContent className="pt-6 relative overflow-hidden">
-							<Code2 className="h-32 w-32 text-blue-500 absolute -top-10 -left-6 opacity-10" />
-							<p className="text-6xl font-semibold text-gray-700">
-								{statsLoading ? '-' : stats?.appCount}
-							</p>
-							<p className="text-md text-gray-500">Total Apps</p>
-						</CardContent>
-					</Card>
-
-					<Card className="text-center hover:shadow-lg hover:scale-[1.02] transition-all dark:bg-bg-4/50">
-						<CardContent className="pt-6 relative overflow-hidden">
-							<Globe className="h-32 w-32 text-green-500 absolute -top-10 -left-6 opacity-20" />
-							<p className="text-6xl font-semibold text-gray-700">
-								{statsLoading ? '-' : stats?.publicAppCount}
-							</p>
-							<p className="text-md text-gray-500">Public Apps</p>
-						</CardContent>
-					</Card>
-
-					<Card className="text-center hover:shadow-lg hover:scale-[1.02] transition-all dark:bg-bg-4/50">
-						<CardContent className="pt-6 relative overflow-hidden">
-							<Activity className="h-32 w-32 text-purple-500 absolute -top-10 -left-6 opacity-10" />
-							<p className="text-6xl font-semibold text-gray-700">
-								{statsLoading ? '-' : stats?.totalViewsReceived}
-							</p>
-							<p className="text-md text-gray-500">Total Views</p>
-						</CardContent>
-					</Card>
-
-					<Card className="text-center hover:shadow-lg hover:scale-[1.02] transition-all dark:bg-bg-4/50">
-						<CardContent className="pt-6 relative overflow-hidden">
-							<Star className="h-32 w-32 text-yellow-500 absolute -top-10 -left-6 opacity-20" />
-							<p className="text-6xl font-semibold text-gray-700">
-								{statsLoading ? '-' : stats?.totalLikesReceived}
-							</p>
-							<p className="text-md text-gray-500">Total Likes</p>
-						</CardContent>
-					</Card>
+				{/* Stats */}
+				<div className="mb-10 grid grid-cols-2 gap-3 sm:grid-cols-4">
+					{STATS.map(({ key, label, icon: Icon, iconClass }) => (
+						<div
+							key={key}
+							className="relative overflow-hidden rounded-xl px-4 py-4 bg-kumo-base ring ring-kumo-line/70"
+						>
+							<Icon
+								className={cn(
+									'pointer-events-none absolute -top-2 -right-5 size-24 rotate-12 opacity-10',
+									iconClass,
+								)}
+								weight="duotone"
+							/>
+							<div className="relative grid gap-1">
+								<p className="text-3xl font-semibold tabular-nums text-kumo-strong">
+									{statsLoading
+										? '–'
+										: formatNumber(stats?.[key] ?? 0)}
+								</p>
+								<p className="text-sm text-kumo-subtle">
+									{label}
+								</p>
+							</div>
+						</div>
+					))}
 				</div>
 
-				<div className="space-y-6">
+				{/* Tabs + content */}
+				<div className="flex flex-col gap-6">
 					<Tabs
 						value={activeTab}
-						onValueChange={setActiveTab}
-						className="w-full max-w-md"
+						onValueChange={handleTabChange}
+						className="w-fit"
 						tabs={[
 							{ value: 'about', label: 'About' },
 							{ value: 'apps', label: 'Apps' },
@@ -259,77 +280,83 @@ export default function Profile() {
 					/>
 
 					{activeTab === 'about' && (
-						<div className="space-y-6">
-							<Card className="dark:bg-bg-4/50 max-w-xl">
-								<CardHeader className="border-b">
-									<CardTitle>Profile Information</CardTitle>
-								</CardHeader>
-								<CardContent className="space-y-6">
-									<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-										<div className="space-y-2">
-											<Label htmlFor="displayName">
-												Display Name
-											</Label>
-											{isEditing ? (
-												<Input
-													id="displayName"
-													value={
-														profileData.displayName
-													}
-													onChange={(e) =>
-														setProfileData({
-															...profileData,
-															displayName:
-																e.target.value,
-														})
-													}
-												/>
-											) : (
+						<LayerCard>
+							<LayerCard.Secondary className="font-funky-mono tracking-tighter">
+								Profile information
+							</LayerCard.Secondary>
+							<LayerCard.Primary>
+								<div className="grid gap-6">
+									<div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+										{isEditing ? (
+											<Input
+												id="displayName"
+												label="Display name"
+												value={profileData.displayName}
+												onChange={(e) =>
+													setProfileData({
+														...profileData,
+														displayName:
+															e.target.value,
+													})
+												}
+											/>
+										) : (
+											<div className="grid gap-1">
 												<p className="text-sm text-kumo-subtle">
-													{user?.displayName}
+													Display name
 												</p>
-											)}
-										</div>
+												<p className="text-sm text-kumo-default">
+													{user?.displayName || '—'}
+												</p>
+											</div>
+										)}
 
-										<div className="space-y-2">
-											<Label htmlFor="username">
-												Username
-											</Label>
-											{isEditing ? (
-												<Input
-													id="username"
-													value={profileData.username}
-													onChange={(e) =>
-														setProfileData({
-															...profileData,
-															username:
-																e.target.value,
-														})
-													}
-													placeholder="@username"
-												/>
-											) : (
+										{isEditing ? (
+											<Input
+												id="username"
+												label="Username"
+												value={profileData.username}
+												onChange={(e) =>
+													setProfileData({
+														...profileData,
+														username:
+															e.target.value,
+													})
+												}
+												placeholder="@username"
+											/>
+										) : (
+											<div className="grid gap-1">
 												<p className="text-sm text-kumo-subtle">
+													Username
+												</p>
+												<p className="text-sm text-kumo-default">
 													{user?.username ||
 														'Not set'}
 												</p>
-											)}
-										</div>
+											</div>
+										)}
 
-										<div className="space-y-2">
-											<Label htmlFor="email">Email</Label>
-											<p className="text-sm text-kumo-subtle flex items-center gap-2">
-												<Mail className="h-4 w-4" />
+										<div className="grid gap-1">
+											<p className="text-sm text-kumo-subtle">
+												Email
+											</p>
+											<p className="flex items-center gap-2 text-sm text-kumo-default">
+												<span className="h-lh flex items-center text-kumo-subtle">
+													<EnvelopeSimple className="size-4" />
+												</span>
 												{user?.email}
 											</p>
 										</div>
 
-										<div className="space-y-2">
-											<Label htmlFor="joined">
-												Member Since
-											</Label>
-											<p className="text-sm text-kumo-subtle flex items-center gap-2">
-												<Calendar className="h-4 w-4" />
+										<div className="grid gap-1">
+											<p className="text-sm text-kumo-subtle">
+												Member since
+											</p>
+											<p className="flex items-center gap-2 text-sm text-kumo-default">
+												<span className="h-lh flex items-center text-kumo-subtle">
+													<CalendarBlank className="size-4" />
+												</span>
 												{user?.createdAt
 													? format(
 															new Date(
@@ -342,289 +369,267 @@ export default function Profile() {
 										</div>
 									</div>
 
-									<div className="space-y-2">
-										<Label htmlFor="bio">Bio</Label>
-										{isEditing ? (
-											<Textarea
-												id="bio"
-												value={profileData.bio}
-												onChange={(e) =>
-													setProfileData({
-														...profileData,
-														bio: e.target.value,
-													})
-												}
-												placeholder="Tell us about yourself..."
-												rows={4}
-											/>
-										) : (
+									{isEditing ? (
+										<InputArea
+											id="bio"
+											label="Bio"
+											value={profileData.bio}
+											onChange={(e) =>
+												setProfileData({
+													...profileData,
+													bio: e.target.value,
+												})
+											}
+											placeholder="Tell us about yourself..."
+											rows={4}
+										/>
+									) : (
+										<div className="grid gap-1">
 											<p className="text-sm text-kumo-subtle">
-												{user?.bio || 'No bio provided'}
+												Bio
 											</p>
-										)}
-									</div>
-								</CardContent>
-							</Card>
-						</div>
+											<p className="text-sm text-kumo-default">
+												{user?.bio ||
+													'No bio yet — hit edit to add one!'}
+											</p>
+										</div>
+									)}
+								</div>
+							</LayerCard.Primary>
+						</LayerCard>
 					)}
 
 					{activeTab === 'apps' && (
-						<div>
-							<Card className="dark:bg-bg-4/50 max-w-xl">
-								<CardHeader className="border-b">
-									<CardTitle>Recent Applications</CardTitle>
-								</CardHeader>
-								<CardContent>
-									{appsLoading ? (
-										<div className="flex items-center justify-center py-8">
-											<div className="text-center">
-												<Activity className="h-8 w-8 mx-auto mb-2 text-kumo-subtle animate-pulse" />
-												<p className="text-sm text-kumo-subtle">
-													Loading apps...
-												</p>
-											</div>
-										</div>
-									) : recentApps && recentApps.length > 0 ? (
-										<div className="space-y-4">
-											{recentApps
-												.slice(0, 5)
-												.map((app) => (
-													<div
-														key={app.id}
-														className="flex items-center justify-between p-4 rounded-lg border hover:bg-kumo-base/50 transition-colors cursor-pointer"
-														onClick={() =>
-															navigate(
-																`/app/${app.id}`,
-															)
-														}
-													>
-														<div className="flex items-center gap-4">
-															<div className="h-12 w-12 rounded-lg bg-kumo-base flex items-center justify-center">
-																<Code2 className="h-6 w-6" />
-															</div>
-															<div>
-																<h4 className="font-medium">
-																	{app.title}
-																</h4>
-																<div className="flex items-center gap-3 mt-1 text-xs text-kumo-subtle">
-																	<Badge
-																		variant="secondary"
-																		className="text-xs"
-																	>
-																		{
-																			app.framework
-																		}
-																	</Badge>
-																	<span className="text-xs">
-																		{app.createdAt
-																			? format(
-																					new Date(
-																						app.createdAt,
-																					),
-																					'MMM d, yyyy',
-																				)
-																			: 'Recently'}
-																	</span>
-																</div>
-															</div>
+						<LayerCard>
+							<LayerCard.Secondary className="font-funky-mono tracking-tighter">
+								Recent apps
+							</LayerCard.Secondary>
+							<LayerCard.Primary>
+								{appsLoading ? (
+									<div className="flex justify-center py-10">
+										<Loader />
+									</div>
+								) : recentApps && recentApps.length > 0 ? (
+									<div className="grid gap-2">
+										{recentApps.slice(0, 5).map((app) => (
+											<button
+												key={app.id}
+												type="button"
+												className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-3 text-left ring ring-kumo-hairline hover:bg-kumo-tint"
+												onClick={() =>
+													navigate(`/app/${app.id}`)
+												}
+											>
+												<div className="flex min-w-0 items-center gap-3">
+													<span className="flex size-10 shrink-0 items-center justify-center rounded-lg text-kumo-subtle">
+														<Code className="size-5" />
+													</span>
+													<div className="min-w-0">
+														<p className="truncate text-sm font-medium text-kumo-default">
+															{app.title}
+														</p>
+														<div className="mt-1 flex flex-wrap items-center gap-2">
+															{app.framework && (
+																<Badge
+																	variant="neutral"
+																	className="text-xs"
+																>
+																	{
+																		app.framework
+																	}
+																</Badge>
+															)}
+															<span className="text-xs text-kumo-subtle">
+																{app.createdAt
+																	? format(
+																			new Date(
+																				app.createdAt,
+																			),
+																			'MMM d, yyyy',
+																		)
+																	: 'Recently'}
+															</span>
 														</div>
-														<Badge
-															variant={
-																app.visibility ===
-																'public'
-																	? 'default'
-																	: 'secondary'
-															}
-														>
-															{app.visibility}
-														</Badge>
 													</div>
-												))}
-										</div>
-									) : (
-										<div className="flex flex-col items-center justify-center py-8">
-											<Code2 className="h-12 w-12 text-kumo-subtle mb-4" />
-											<p className="text-kumo-subtle">
-												No apps created yet
-											</p>
+												</div>
+												<Badge
+													variant={
+														app.visibility ===
+														'public'
+															? 'success'
+															: 'secondary'
+													}
+												>
+													{app.visibility}
+												</Badge>
+											</button>
+										))}
+									</div>
+								) : (
+									<Empty
+										size="sm"
+										icon={
+											<Code
+												size={40}
+												className="text-kumo-inactive"
+												weight="duotone"
+											/>
+										}
+										title="No apps yet"
+										description="Build something fun — your first app is one prompt away."
+										contents={
 											<Button
-												className="mt-4"
+												variant="primary"
+												size="sm"
 												onClick={() =>
 													navigate('/chat')
 												}
 											>
-												Create Your First App
+												Create your first app
 											</Button>
-										</div>
-									)}
-								</CardContent>
-							</Card>
-						</div>
+										}
+									/>
+								)}
+							</LayerCard.Primary>
+						</LayerCard>
 					)}
 
 					{activeTab === 'achievements' && (
-						<div>
-							<Card className="dark:bg-bg-4/50 max-w-xl">
-								<CardHeader>
-									<CardTitle>Achievements</CardTitle>
-								</CardHeader>
-								<CardContent>
-									{statsLoading ? (
-										<div className="flex items-center justify-center py-8">
-											<div className="text-center">
-												<Trophy className="h-8 w-8 mx-auto mb-2 text-kumo-subtle animate-pulse" />
-												<p className="text-sm text-kumo-subtle">
-													Loading achievements...
-												</p>
-											</div>
-										</div>
-									) : achievements &&
-									  achievements.length > 0 ? (
-										<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-											{achievements.map(
-												(achievement, index) => {
-													return (
-														<div
-															key={index}
-															className="p-4 rounded-lg border hover:shadow-md transition-shadow"
-														>
-															<div className="flex items-start gap-4">
-																<div className="p-3 rounded-lg bg-kumo-base text-kumo-subtle">
-																	<Trophy className="h-6 w-6" />
-																</div>
-																<div className="flex-1">
-																	<h4 className="font-medium">
-																		{
-																			achievement
-																		}
-																	</h4>
-																	<p className="text-sm text-kumo-subtle mt-1">
-																		Achievement
-																		unlocked!
-																	</p>
-																</div>
-															</div>
-														</div>
-													);
-												},
-											)}
-										</div>
-									) : (
-										<div className="flex flex-col items-center justify-center py-8">
-											<Trophy className="h-12 w-12 text-kumo-subtle mb-4" />
-											<p className="text-kumo-subtle">
-												No achievements yet
-											</p>
-											<p className="text-sm text-kumo-subtle mt-2">
-												Start creating apps to unlock
-												achievements!
-											</p>
-										</div>
-									)}
-								</CardContent>
-							</Card>
-						</div>
+						<LayerCard>
+							<LayerCard.Secondary className="font-funky-mono tracking-tighter">
+								Achievements
+							</LayerCard.Secondary>
+							<LayerCard.Primary>
+								{statsLoading ? (
+									<div className="flex justify-center py-10">
+										<Loader />
+									</div>
+								) : achievements && achievements.length > 0 ? (
+									<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+										{achievements.map(
+											(achievement, index) => (
+												<div
+													key={index}
+													className="flex items-start gap-3 rounded-lg px-3 py-3 ring ring-kumo-hairline"
+												>
+													<span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400">
+														<Trophy
+															className="size-5"
+															weight="duotone"
+														/>
+													</span>
+													<div className="min-w-0 grid gap-0.5">
+														<p className="text-sm font-medium text-kumo-default">
+															{achievement}
+														</p>
+														<p className="text-sm text-kumo-subtle">
+															Unlocked — nice
+															work!
+														</p>
+													</div>
+												</div>
+											),
+										)}
+									</div>
+								) : (
+									<Empty
+										size="sm"
+										icon={
+											<Trophy
+												size={40}
+												className="text-kumo-inactive"
+												weight="duotone"
+											/>
+										}
+										title="No achievements yet"
+										description="Create apps and share them to unlock badges."
+									/>
+								)}
+							</LayerCard.Primary>
+						</LayerCard>
 					)}
 
 					{activeTab === 'activity' && (
-						<div>
-							<Card className="dark:bg-bg-4/50 max-w-xl">
-								<CardHeader>
-									<CardTitle>Activity Timeline</CardTitle>
-								</CardHeader>
-								<CardContent>
-									{activityLoading ? (
-										<div className="flex items-center justify-center py-8">
-											<div className="text-center">
-												<Activity className="h-8 w-8 mx-auto mb-2 text-kumo-subtle animate-pulse" />
-												<p className="text-sm text-kumo-subtle">
-													Loading activity...
-												</p>
+						<LayerCard>
+							<LayerCard.Secondary className="font-funky-mono tracking-tighter">
+								Activity
+							</LayerCard.Secondary>
+							<LayerCard.Primary>
+								{activityLoading ? (
+									<div className="flex justify-center py-10">
+										<Loader />
+									</div>
+								) : activities && activities.length > 0 ? (
+									<div className="grid gap-0">
+										{activities.map((activity, index) => (
+											<div
+												key={index}
+												className="flex items-start gap-3 border-b border-kumo-line/50 py-3 last:border-0 last:pb-0 first:pt-0"
+											>
+												<span className="flex size-8 shrink-0 items-center justify-center rounded-lg text-kumo-subtle">
+													{activity.type ===
+														'created' && (
+														<Lightning className="size-4" />
+													)}
+													{activity.type ===
+														'updated' && (
+														<PencilSimple className="size-4" />
+													)}
+													{activity.type ===
+														'favorited' && (
+														<Star className="size-4" />
+													)}
+												</span>
+												<div className="min-w-0 flex-1 grid gap-0.5">
+													<p className="text-sm text-kumo-default">
+														<span className="font-medium">
+															{activity.type ===
+																'created' &&
+																'Created'}
+															{activity.type ===
+																'updated' &&
+																'Updated'}
+															{activity.type ===
+																'favorited' &&
+																'Favorited'}
+														</span>{' '}
+														<span className="text-kumo-subtle">
+															{activity.title}
+														</span>
+													</p>
+													<p className="text-xs text-kumo-subtle">
+														{activity.timestamp
+															? format(
+																	new Date(
+																		activity.timestamp,
+																	),
+																	'MMM d, yyyy h:mm a',
+																)
+															: 'Recently'}
+													</p>
+												</div>
 											</div>
-										</div>
-									) : activities && activities.length > 0 ? (
-										<div className="space-y-4">
-											{activities.map(
-												(activity, index) => (
-													<div
-														key={index}
-														className="flex items-start gap-4 pb-4 border-b last:border-0"
-													>
-														<div
-															className={cn(
-																'p-2 rounded-lg',
-																activity.type ===
-																	'created' &&
-																	'bg-green-500/10 text-green-600',
-																activity.type ===
-																	'updated' &&
-																	'bg-blue-500/10 text-blue-600',
-																activity.type ===
-																	'favorited' &&
-																	'bg-yellow-500/10 text-yellow-600',
-															)}
-														>
-															{activity.type ===
-																'created' && (
-																<Zap className="h-4 w-4" />
-															)}
-															{activity.type ===
-																'updated' && (
-																<Edit3 className="h-4 w-4" />
-															)}
-															{activity.type ===
-																'favorited' && (
-																<Star className="h-4 w-4" />
-															)}
-														</div>
-														<div className="flex-1">
-															<p className="text-sm">
-																<span className="font-medium">
-																	{activity.type ===
-																		'created' &&
-																		'Created'}
-																	{activity.type ===
-																		'updated' &&
-																		'Updated'}
-																	{activity.type ===
-																		'favorited' &&
-																		'Favorited'}
-																</span>{' '}
-																<span className="text-kumo-subtle">
-																	{
-																		activity.title
-																	}
-																</span>
-															</p>
-															<p className="text-xs text-kumo-subtle mt-1">
-																{activity.timestamp
-																	? format(
-																			new Date(
-																				activity.timestamp,
-																			),
-																			'MMM d, yyyy h:mm a',
-																		)
-																	: 'Recently'}
-															</p>
-														</div>
-													</div>
-												),
-											)}
-										</div>
-									) : (
-										<div className="flex flex-col items-center justify-center py-8">
-											<Activity className="h-12 w-12 text-kumo-subtle mb-4" />
-											<p className="text-kumo-subtle">
-												No recent activity
-											</p>
-										</div>
-									)}
-								</CardContent>
-							</Card>
-						</div>
+										))}
+									</div>
+								) : (
+									<Empty
+										size="sm"
+										icon={
+											<Pulse
+												size={40}
+												className="text-kumo-inactive"
+												weight="duotone"
+											/>
+										}
+										title="No recent activity"
+										description="Your creations and updates will show up here."
+									/>
+								)}
+							</LayerCard.Primary>
+						</LayerCard>
 					)}
 				</div>
-			</div>
+			</main>
 		</div>
 	);
 }

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -144,6 +144,11 @@ export default function Profile() {
 
 	return (
 		<div className="min-h-screen">
+			<title>
+				{user?.displayName
+					? `${user.displayName} - Profile - Build`
+					: 'Profile - Build'}
+			</title>
 			<main className="container mx-auto max-w-4xl px-4 py-12 pb-24">
 				{/* Header */}
 				<div className="mb-10 flex flex-col items-center gap-6 sm:flex-row sm:items-start">

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -215,6 +215,7 @@ export default function SettingsPage() {
 
 	return (
 		<div className="relative">
+			<title>Settings - Build</title>
 			<main className="container mx-auto px-4 py-16 max-w-4xl pb-48">
 				<div className="grid gap-8">
 					{/* Page Header */}


### PR DESCRIPTION
Redesigns the public profile page and introduces a new shared orange gradient button.

What changed:
- Redesigned `src/routes/profile.tsx` and linked it in routing
- Removed unused Google Fonts imports from `index.html`
- Added a new `OrangeButton` shared component and used it across the app shell
- Updated sidebar, global header, auth button, prompt box, and discover/home pages
- Added/updated helpers in `src/lib/utils.ts` and tests
- fix: use per page titles as per context — added contextual `<title>` updates to app, apps, chat, discover, home, profile, and settings routes

