### PR TITLE
fix(sidebar): sidebar, app header and chat route ui fixes

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -10,7 +10,7 @@ import {
 	UsersThreeIcon,
 } from '@phosphor-icons/react';
 import { isValid } from 'date-fns';
-import { useLocation, useNavigate } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 import {
 	Button,
 	CloudflareLogo,
@@ -237,9 +237,7 @@ export function AppSidebar() {
 			case 'private':
 				return <LockKeyIcon className="size-3.5" weight="duotone" />;
 			case 'team':
-				return (
-					<UsersThreeIcon className="size-3.5" weight="duotone" />
-				);
+				return <UsersThreeIcon className="size-3.5" weight="duotone" />;
 			case 'board':
 			case 'public':
 				return (
@@ -254,7 +252,10 @@ export function AppSidebar() {
 	return (
 		<Sidebar className="[--sidebar-bg:var(--color-kumo-canvas)]">
 			<Sidebar.Header
-				className={cn('h-12', isCollapsed ? 'justify-center px-0' : 'px-3')}
+				className={cn(
+					'h-12',
+					isCollapsed ? 'justify-center px-0' : 'px-3',
+				)}
 			>
 				{isCollapsed ? (
 					<div className="relative flex size-9 items-center justify-center">
@@ -268,114 +269,122 @@ export function AppSidebar() {
 						/>
 					</div>
 				) : (
-					<div className="flex w-full min-w-0 items-center gap-2.5 text-kumo-strong">
+					<Link
+						to="/"
+						className="flex w-full min-w-0 items-center gap-2.5 text-kumo-strong"
+					>
 						<CloudflareLogo
 							variant="glyph"
 							className="size-7 shrink-0"
 						/>
-						<span className="min-w-0 flex-1 truncate text-sm font-black font-funky-mono uppercase tracking-[0.25em]">
+						<span className="min-w-0 flex-1 truncate text-base font-black font-funky-mono uppercase tracking-wide">
 							Build
 						</span>
 						<Sidebar.Trigger
 							aria-label="Collapse sidebar"
 							className="ml-auto shrink-0"
 						/>
-					</div>
+					</Link>
 				)}
 			</Sidebar.Header>
 
-			<Sidebar.Content>
-				<Sidebar.Group>
-					{isCollapsed ? (
-						<div className="flex flex-col items-center gap-1">
+			<div className="shrink-0 px-[11px] py-3 group-not-data-[state=collapsed]/sidebar:px-3.5">
+				{isCollapsed ? (
+					<div className="flex flex-col items-center gap-1">
+						{pathname !== '/' && (
+							<OrangeButton
+								shape="square"
+								aria-label="New build"
+								title="New build"
+								onClick={() => navigate('/')}
+								className="size-8!"
+								icon={
+									<PlusIcon
+										className="size-4"
+										weight="bold"
+									/>
+								}
+							/>
+						)}
+						<Button
+							shape="square"
+							size="base"
+							variant="ghost"
+							id="discover-link"
+							aria-label="Discover"
+							title="Discover"
+							aria-current={
+								pathname === '/discover' ? 'page' : undefined
+							}
+							onClick={() => navigate('/discover')}
+							className={cn(
+								'text-kumo-subtle hover:text-kumo-default',
+								pathname === '/discover' &&
+									'bg-(--sidebar-active-bg) text-kumo-default',
+							)}
+							icon={<CompassIcon className="size-4" />}
+						/>
+					</div>
+				) : (
+					<div className="flex flex-col gap-1.5">
+						<Sidebar.Menu className="gap-y-1.5">
 							{pathname !== '/' && (
 								<OrangeButton
-									shape="square"
-									aria-label="New build"
-									title="New build"
-									onClick={() => navigate('/')}
-									className="size-8!"
+									fullWidth
 									icon={
 										<PlusIcon
 											className="size-4"
 											weight="bold"
 										/>
 									}
-								/>
-							)}
-							<Button
-								shape="square"
-								size="base"
-								variant="ghost"
-								id="discover-link"
-								aria-label="Discover"
-								title="Discover"
-								aria-current={
-									pathname === '/discover' ? 'page' : undefined
-								}
-								onClick={() => navigate('/discover')}
-								className={cn(
-									'text-kumo-subtle hover:text-kumo-default',
-									pathname === '/discover' &&
-										'bg-(--sidebar-active-bg) text-kumo-default',
-								)}
-								icon={<CompassIcon className="size-4" />}
-							/>
-						</div>
-					) : (
-						<div className="flex flex-col gap-1.5">
-							<Sidebar.Menu className="gap-y-1.5">
-								{pathname !== '/' && (
-									<OrangeButton
-										fullWidth
-										icon={
-											<PlusIcon
-												className="size-4"
-												weight="bold"
-											/>
-										}
-										title="New build"
-										onClick={() => navigate('/')}
-										className="h-8! text-sm"
-									>
-										New build
-									</OrangeButton>
-								)}
-
-								<Sidebar.MenuButton
-									active={pathname === '/discover'}
-									icon={CompassIcon}
-									id="discover-link"
-									tooltip="Discover"
-									onClick={() => navigate('/discover')}
+									title="New build"
+									onClick={() => {
+										navigate('/');
+									}}
+									className="h-8! text-sm"
 								>
-									Discover
-								</Sidebar.MenuButton>
-							</Sidebar.Menu>
-
-							{user && (
-								<div className="px-0.5">
-									<InputGroup>
-										<InputGroup.Addon>
-											<MagnifyingGlassIcon className="size-3.5 text-kumo-subtle" />
-										</InputGroup.Addon>
-										<InputGroup.Input
-											aria-label="Search apps"
-											placeholder="Search apps"
-											value={searchQuery}
-											onChange={(event) =>
-												setSearchQuery(
-													event.target.value,
-												)
-											}
-										/>
-									</InputGroup>
-								</div>
+									New build
+								</OrangeButton>
 							)}
-						</div>
-					)}
-				</Sidebar.Group>
 
+							<Sidebar.MenuButton
+								active={pathname === '/discover'}
+								icon={
+									<CompassIcon
+										weight="duotone"
+										className="size-4 -mr-1"
+									/>
+								}
+								id="discover-link"
+								tooltip="Discover"
+								onClick={() => navigate('/discover')}
+							>
+								Discover
+							</Sidebar.MenuButton>
+						</Sidebar.Menu>
+
+						{user && (
+							<div className="px-0.5">
+								<InputGroup>
+									<InputGroup.Addon>
+										<MagnifyingGlassIcon className="size-4 text-kumo-subtle" />
+									</InputGroup.Addon>
+									<InputGroup.Input
+										aria-label="Search apps"
+										placeholder="Search apps"
+										value={searchQuery}
+										onChange={(event) =>
+											setSearchQuery(event.target.value)
+										}
+									/>
+								</InputGroup>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			<Sidebar.Content>
 				{!isCollapsed && showBookmarksSection && (
 					<Sidebar.Group>
 						<Sidebar.GroupLabel>
@@ -584,12 +593,12 @@ export function AppSidebar() {
 								<CloudflareLogo
 									variant="glyph"
 									color="white"
-									className="size-5 shrink-0"
+									className="size-6 shrink-0"
 								/>
 							}
 						>
 							{!isCollapsed ? (
-								<span className="truncate">
+								<span className="truncate text-xs">
 									{cloudflareCtaLabel}
 								</span>
 							) : null}

--- a/src/components/prompt-box.tsx
+++ b/src/components/prompt-box.tsx
@@ -261,6 +261,7 @@ export function PromptBox({
 							className="w-full resize-none ring-0 z-20 outline-0 placeholder:text-text-primary/60 text-text-primary group"
 							value={value}
 							placeholder={resolvedPlaceholder}
+							autoFocus
 							ref={(textarea) => {
 								(
 									internalTextareaRef as React.MutableRefObject<HTMLTextAreaElement | null>

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -609,7 +609,7 @@ export default function AppView() {
 	return (
 		<div className="size-full flex flex-col min-h-0">
 			<title>{app.title ? `${app.title} - Build` : 'App - Build'}</title>
-			<div className="shrink-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between px-4 py-2 border-b">
+			<div className="shrink-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between px-4 py-2 border-b bg-kumo-base">
 				<Tabs
 					value={activeTab}
 					onValueChange={setActiveTab}

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -1162,7 +1162,7 @@ export default function Chat() {
 				<div className="flex-1 flex min-h-0 overflow-hidden justify-center">
 					<motion.div
 						layout="position"
-						className="flex-1 shrink-0 flex flex-col basis-0 max-w-2xl relative z-10 h-full min-h-0"
+						className={cn("flex-1 shrink-0 flex flex-col basis-0 relative z-10 h-full min-h-0", showMainView ? 'max-w-2xl' : 'max-w-3xl')}
 					>
 						<div
 							className={cn(

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -14,10 +14,16 @@ import {
 } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ExternalLink, LoaderCircle, MoreHorizontal, Rocket, RotateCcw } from 'lucide-react';
+import {
+	ExternalLink,
+	LoaderCircle,
+	Rocket,
+	RotateCcw,
+} from 'lucide-react';
 import {
 	BookmarkSimpleIcon,
 	DotsThree,
+	DotsThreeIcon,
 	GitBranch,
 	Globe,
 	Lock,
@@ -1196,7 +1202,7 @@ export default function Chat() {
 																shape="square"
 																aria-label="Chat actions"
 																icon={
-																	MoreHorizontal
+																	<DotsThreeIcon className="size-4.5" />
 																}
 															/>
 														}

--- a/src/routes/chat/utils/tool-display.ts
+++ b/src/routes/chat/utils/tool-display.ts
@@ -81,7 +81,7 @@ const VERBS: Record<string, VerbSet> = {
 	deploy_space: { start: 'Deploying', success: 'Deployed', error: 'Failed to deploy' },
 	deploy_preview: { start: 'Deploying preview', success: 'Deployed preview', error: 'Failed to deploy preview' },
 	set_title: { start: 'Setting title', success: 'Set title', error: 'Failed to set title' },
-	ask_questions: { start: 'Asking questions', success: 'Asked questions', error: 'Failed to ask questions' },
+	ask_questions: { start: 'Asking', success: 'Asked', error: 'Failed to ask' },
 	get_browser_console_logs: {
 		start: 'Checking browser console',
 		success: 'Checked browser console',
@@ -234,6 +234,7 @@ function groupNoun(name: string, count: number): string {
 		read_files: ['file batch', 'file batches'],
 		commit: ['commit', 'commits'],
 		web_search: ['search', 'searches'],
+		ask_questions: ['question set', 'question sets'],
 	};
 	const pair = nouns[name] ?? ['step', 'steps'];
 	return count === 1 ? pair[0] : pair[1];


### PR DESCRIPTION
Small UI polish batch for the sidebar, app header, prompt box, chat layout, and tool-call labels.

### What changed
- **App sidebar:** logo now links back to home; simplified top action layout; restyled search icon; adjusted Cloudflare CTA sizing.
- **App header:** added `bg-kumo-base` to the app view header.
- **Prompt box:** auto-focus the textarea on render.
- **Chat:** widen the chat column when the main view is hidden; replaced `MoreHorizontal` with `DotsThreeIcon`.
- **Tool display:** shortened `ask_questions` labels and added pluralization ("question set"/"question sets").
