### PR TITLE
feat: route owned apps to editor and prefer Think live preview

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -34,6 +34,7 @@ interface App {
 	updatedAt: Date | string | null;
 	updatedAtFormatted?: string;
 	visibility: 'private' | 'team' | 'board' | 'public';
+	userId?: string | null;
 	isFavorite?: boolean;
 }
 
@@ -54,6 +55,7 @@ interface AppMenuItemProps {
 	showActions?: boolean;
 	isCollapsed: boolean;
 	getVisibilityIcon: (visibility: App['visibility']) => React.ReactNode;
+	appPath: string;
 }
 
 function AppMenuItem({
@@ -64,6 +66,7 @@ function AppMenuItem({
 	showActions = true,
 	isCollapsed,
 	getVisibilityIcon,
+	appPath,
 }: AppMenuItemProps) {
 	const formatTimestamp = () => {
 		const updatedAt =
@@ -99,7 +102,7 @@ function AppMenuItem({
 		<Sidebar.MenuItem className="group/app-item">
 			<Sidebar.MenuButton
 				active={active}
-				href={`/app/${app.id}`}
+				href={appPath}
 				tooltip={app.title}
 				className="min-h-12 items-start py-2 pr-9 text-sm"
 				onClick={(event) => {
@@ -179,6 +182,8 @@ export function AppSidebar() {
 	const { apps: favoriteApps, loading: favoriteAppsLoading } =
 		useFavoriteApps();
 	const { apps: allApps, loading: allAppsLoading } = useApps();
+	const getAppPath = (app: App) =>
+		app.userId === user?.id ? `/chat/${app.id}` : `/app/${app.id}`;
 
 	const boards: Board[] = [];
 
@@ -269,22 +274,24 @@ export function AppSidebar() {
 						/>
 					</div>
 				) : (
-					<Link
-						to="/"
-						className="flex w-full min-w-0 items-center gap-2.5 text-kumo-strong"
-					>
-						<CloudflareLogo
-							variant="glyph"
-							className="size-7 shrink-0"
-						/>
-						<span className="min-w-0 flex-1 truncate text-base font-black font-funky-mono uppercase tracking-wide">
-							Build
-						</span>
+					<div className="flex w-full min-w-0 items-center gap-2.5">
+						<Link
+							to="/"
+							className="flex min-w-0 flex-1 items-center gap-2.5 text-kumo-strong"
+						>
+							<CloudflareLogo
+								variant="glyph"
+								className="size-7 shrink-0"
+							/>
+							<span className="min-w-0 flex-1 truncate text-base font-black font-funky-mono uppercase tracking-wide">
+								Build
+							</span>
+						</Link>
 						<Sidebar.Trigger
 							aria-label="Collapse sidebar"
 							className="ml-auto shrink-0"
 						/>
-					</Link>
+					</div>
 				)}
 			</Sidebar.Header>
 
@@ -405,11 +412,12 @@ export function AppSidebar() {
 										<AppMenuItem
 											key={app.id}
 											app={app}
+											appPath={getAppPath(app)}
 											active={
-												pathname === `/app/${app.id}`
+												pathname === getAppPath(app)
 											}
-											onClick={(id) =>
-												navigate(`/app/${id}`)
+											onClick={() =>
+												navigate(getAppPath(app))
 											}
 											variant="bookmarked"
 											isCollapsed={isCollapsed}
@@ -430,8 +438,11 @@ export function AppSidebar() {
 									<AppMenuItem
 										key={app.id}
 										app={app}
-										active={pathname === `/app/${app.id}`}
-										onClick={(id) => navigate(`/app/${id}`)}
+										appPath={getAppPath(app)}
+										active={pathname === getAppPath(app)}
+										onClick={() =>
+											navigate(getAppPath(app))
+										}
 										variant="bookmarked"
 										isCollapsed={isCollapsed}
 										getVisibilityIcon={getVisibilityIcon}
@@ -462,11 +473,12 @@ export function AppSidebar() {
 										<AppMenuItem
 											key={app.id}
 											app={app}
+											appPath={getAppPath(app)}
 											active={
-												pathname === `/app/${app.id}`
+												pathname === getAppPath(app)
 											}
-											onClick={(id) =>
-												navigate(`/app/${id}`)
+											onClick={() =>
+												navigate(getAppPath(app))
 											}
 											isCollapsed={isCollapsed}
 											getVisibilityIcon={
@@ -487,11 +499,12 @@ export function AppSidebar() {
 										<AppMenuItem
 											key={app.id}
 											app={app}
+											appPath={getAppPath(app)}
 											active={
-												pathname === `/app/${app.id}`
+												pathname === getAppPath(app)
 											}
-											onClick={(id) =>
-												navigate(`/app/${id}`)
+											onClick={() =>
+												navigate(getAppPath(app))
 											}
 											isCollapsed={isCollapsed}
 											getVisibilityIcon={

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/contexts/auth-context';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useAuthGuard } from '@/hooks/useAuthGuard';
 import { ApiError } from '@/lib/api-client';
-import { capitalizeFirstLetter } from '@/lib/utils';
+import { capitalizeFirstLetter, getPreviewUrl } from '@/lib/utils';
 import { getFileType } from '@/utils/string';
 import {
 	Badge,
@@ -105,10 +105,14 @@ export default function AppView() {
 	const [isGitCloneModalOpen, setIsGitCloneModalOpen] = useState(false);
 	const [activeFilePath, setActiveFilePath] = useState<string>();
 	const previewIframeRef = useRef<HTMLIFrameElement>(null);
+	const autoDeployAppIdRef = useRef<string | undefined>(undefined);
+	const [thinkPreviewUrl, setThinkPreviewUrl] = useState<string>();
 
 	// Route reuses this component across /app/:id — clear deploy UI on switch
 	useEffect(() => {
 		setDeploymentProgress('');
+		autoDeployAppIdRef.current = undefined;
+		setThinkPreviewUrl(undefined);
 		setActiveTab('preview');
 		setActiveFilePath(undefined);
 	}, [id]);
@@ -336,8 +340,19 @@ export default function AppView() {
 	]);
 
 	const isOwner = !!app && app.userId === user?.id;
-	const appUrl =
-		ownerPreviewUrl || app?.cloudflareUrl || app?.previewUrl || '';
+	const isThink = app?.behaviorType === 'think';
+	// Think apps auto-load their live SpaceDO preview for signed-in viewers
+	// (see the effect below). Anonymous viewers can't hit the auth-gated deploy
+	// endpoint, so they fall back to the same manual affordance as non-Think apps.
+	const isAutoLoadingPreview = isThink && !!user;
+	// Think prefers its live preview over the production deployment link. For
+	// signed-in viewers we withhold the deployed link until the preview resolves
+	// so the preview always wins; anonymous viewers fall back to it.
+	const appUrl = isThink
+		? user
+			? thinkPreviewUrl || ''
+			: app?.cloudflareUrl || app?.previewUrl || ''
+		: ownerPreviewUrl || app?.cloudflareUrl || app?.previewUrl || '';
 	const promptText = app?.agentSummary?.query || app?.originalPrompt || '';
 
 	const handleCopyUrl = () => {
@@ -363,6 +378,38 @@ export default function AppView() {
 			});
 		}
 	};
+
+	// Auto-load the preview for Think apps so viewers don't have to click
+	// "Deploy". Gated to authenticated users: the preview endpoint requires
+	// auth (and applies per-user rate limiting), so anonymous visitors would
+	// only get a 401. They still see the manual deploy affordance below.
+	useEffect(() => {
+		if (
+			!app ||
+			!user ||
+			app.behaviorType !== 'think' ||
+			thinkPreviewUrl ||
+			autoDeployAppIdRef.current === app.id
+		) {
+			return;
+		}
+
+		autoDeployAppIdRef.current = app.id;
+		setDeploymentProgress('Loading preview...');
+		void deployPreview()
+			.then((data) => {
+				const url = getPreviewUrl(data.previewURL, data.tunnelURL);
+				if (url) setThinkPreviewUrl(url);
+			})
+			.catch((error) => {
+				console.error('Error loading Think preview:', error);
+				setDeploymentProgress('Failed to load preview');
+				toast.add({
+					title: 'Failed to load preview',
+					variant: 'error',
+				});
+			});
+	}, [app, thinkPreviewUrl, deployPreview, toast, user]);
 
 	const handleToggleVisibility = useCallback(async () => {
 		if (!app || !user || !isOwner) {
@@ -772,11 +819,14 @@ export default function AppView() {
 									<div className="relative z-10 text-center p-8 grid gap-4 max-w-md">
 										<div className="grid gap-1.5">
 											<h3 className="text-xl font-semibold">
-												Run app
+												{isAutoLoadingPreview
+													? 'Loading preview'
+													: 'Run app'}
 											</h3>
 											<p className="text-kumo-subtle text-sm">
-												Deploy a preview to see this app
-												live.
+												{isAutoLoadingPreview
+													? 'Preparing this app preview.'
+													: 'Deploy a preview to see this app live.'}
 											</p>
 											{deploymentProgress && (
 												<p className="text-sm text-kumo-subtle">
@@ -784,23 +834,27 @@ export default function AppView() {
 												</p>
 											)}
 										</div>
-										<div className="flex justify-center">
-											<Button
-												variant="primary"
-												onClick={handlePreviewDeploy}
-												disabled={isDeploying}
-												loading={isDeploying}
-												icon={
-													!isDeploying ? (
-														<Play className="h-4 w-4" />
-													) : undefined
-												}
-											>
-												{isDeploying
-													? 'Deploying...'
-													: 'Deploy for preview'}
-											</Button>
-										</div>
+										{!isAutoLoadingPreview && (
+											<div className="flex justify-center">
+												<Button
+													variant="primary"
+													onClick={
+														handlePreviewDeploy
+													}
+													disabled={isDeploying}
+													loading={isDeploying}
+													icon={
+														!isDeploying ? (
+															<Play className="h-4 w-4" />
+														) : undefined
+													}
+												>
+													{isDeploying
+														? 'Deploying...'
+														: 'Deploy for preview'}
+												</Button>
+											</div>
+										)}
 									</div>
 								</div>
 							)}

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -435,7 +435,7 @@ export default function Chat() {
 							</Button>
 						</>
 					)}
-					{isOwner && app && (
+					{isOwner && app?.visibility === 'private' && (
 						<Button
 							variant="secondary"
 							size="sm"
@@ -443,22 +443,23 @@ export default function Chat() {
 							disabled={isUpdatingVisibility}
 							loading={isUpdatingVisibility}
 							icon={
-								app.visibility === 'private' ? (
-									<LockOpen
-										className="size-3.5"
-										weight="duotone"
-									/>
-								) : (
-									<Lock
-										className="size-3.5"
-										weight="duotone"
-									/>
-								)
+								<LockOpen
+									className="size-3.5"
+									weight="duotone"
+								/>
 							}
 						>
-							{app.visibility === 'private'
-								? 'Make public'
-								: 'Make private'}
+							Make public
+						</Button>
+					)}
+					{isOwner && app?.visibility === 'public' && (
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={() => navigate(`/app/${app.id}`)}
+							icon={<ExternalLink className="size-3.5" />}
+						>
+							View public preview
 						</Button>
 					)}
 					{app && (
@@ -483,6 +484,14 @@ export default function Chat() {
 								>
 									{isFavorited ? 'Bookmarked' : 'Bookmark'}
 								</DropdownMenu.Item>
+								{isOwner && app.visibility === 'public' && (
+									<DropdownMenu.Item
+										icon={Lock}
+										onClick={handleToggleVisibility}
+									>
+										Make private
+									</DropdownMenu.Item>
+								)}
 								<DropdownMenu.Item
 									icon={GitBranch}
 									onClick={() => setIsGitCloneModalOpen(true)}
@@ -501,6 +510,7 @@ export default function Chat() {
 		headerTitle,
 		app,
 		isOwner,
+		navigate,
 		isUpdatingVisibility,
 		handleToggleVisibility,
 		handleFavorite,

--- a/worker/agents/core/codingAgent.ts
+++ b/worker/agents/core/codingAgent.ts
@@ -383,6 +383,10 @@ export class CodeGeneratorAgent extends Agent<Env, AgentState> implements AgentI
         return this.behavior.getSummary();
     }
 
+    getBehaviorType(): BehaviorType {
+        return this.state.behaviorType;
+    }
+
     /**
      * Public RPC entrypoint for the think agent's tools (and any other caller
      * holding a `CodeGenObject` stub) to capture browser console

--- a/worker/api/controllers/appView/controller.ts
+++ b/worker/api/controllers/appView/controller.ts
@@ -10,7 +10,7 @@ import {
     GitCloneTokenData,
     PreviewTokenData,
 } from './types';
-import { AgentSummary } from '../../../agents/core/types';
+import { AgentSummary, BehaviorType } from '../../../agents/core/types';
 import { createLogger } from '../../../logger';
 import { buildUserWorkerUrl, buildGitCloneUrl } from 'worker/utils/urls';
 import { JWTUtils } from '../../../utils/jwtUtils';
@@ -61,13 +61,19 @@ export class AppViewController extends BaseController {
             // Try to fetch current agent state to get latest generated code
             let agentSummary: AgentSummary | null = null;
             let previewUrl: string = '';
+            let behaviorType: BehaviorType | null = null;
             
             try {
                 // Use lightweight stub for read-only operations (faster - skips template loading)
                 const agentStub = await getAgentStubLightweight(env, appResult.id);
-                agentSummary = await agentStub.getSummary();
-
-                previewUrl = await agentStub.getPreviewUrlCache();
+                const [summary, previewUrlCache, agentBehaviorType] = await Promise.all([
+                    agentStub.getSummary(),
+                    agentStub.getPreviewUrlCache(),
+                    agentStub.getBehaviorType(),
+                ]);
+                agentSummary = summary;
+                previewUrl = previewUrlCache;
+                behaviorType = agentBehaviorType;
             } catch (agentError) {
                 // If agent doesn't exist or error occurred, fall back to database stored files
                 this.logger.warn('Could not fetch agent state, using stored files:', agentError);
@@ -79,6 +85,7 @@ export class AppViewController extends BaseController {
                 ...appResult, // Spread all EnhancedAppData fields including stats
                 cloudflareUrl: cloudflareUrl,
                 previewUrl: previewUrl || cloudflareUrl,
+                behaviorType,
                 user: {
                     id: appResult.userId!,
                     displayName: appResult.userName || 'Unknown',

--- a/worker/api/controllers/appView/types.ts
+++ b/worker/api/controllers/appView/types.ts
@@ -3,7 +3,7 @@
  * Following strict DRY principles by reusing existing database types
  */
 
-import { AgentSummary } from '../../../agents/core/types';
+import { AgentSummary, BehaviorType } from '../../../agents/core/types';
 import { EnhancedAppData } from '../../../database/types';
 
 /**
@@ -22,6 +22,7 @@ export interface GeneratedCodeFile {
 export interface AppDetailsData extends EnhancedAppData {
     cloudflareUrl: string | null;
     previewUrl: string | null;
+    behaviorType: BehaviorType | null;
     user: {
         id: string;
         displayName: string;


### PR DESCRIPTION
1. Clicking on an app in the sidebar will lead to the app opening in edit page by default
2. Opening a public app will lead to the preview being loaded automatically

<img width="1207" height="474" alt="Screenshot 2026-08-04 at 1 57 39 PM" src="https://github.com/user-attachments/assets/1d9670a2-f6c1-42a9-bd10-f1756bcec87e" />
Page that opens when you click on an app in the sidebar (and you obviously own)

<img width="1206" height="499" alt="Screenshot 2026-08-04 at 1 57 54 PM" src="https://github.com/user-attachments/assets/de7f287a-8c6a-4c22-937b-5f3e90e119b7" />
When you open a public app that you own you can see the public preview by clicking on the button on top right

<img width="1206" height="600" alt="Screenshot 2026-08-04 at 1 58 08 PM" src="https://github.com/user-attachments/assets/fd3c20c8-9563-4582-8fe4-92174962d55b" />
Owner looking at public preview of their app
