### PR TITLE
fix: harden AI Gateway proxy against unbounded requests (CWE-770)

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -310,18 +310,20 @@ const worker = {
 			}
 			// AI Gateway proxy for generated apps
 			if (pathname.startsWith('/api/proxy/openai')) {
-                // Only handle requests from valid origins of the preview domain
+                // Browser-originated requests must come from a preview-domain
+                // subdomain or an explicitly allowed origin. Server-side calls
+                // from generated apps carry no Origin header and are allowed
+                // through (auth is enforced by the app-proxy JWT downstream).
                 const origin = request.headers.get('Origin');
-                const previewDomain = getPreviewDomain(env);
-
-                logger.info(`Origin: ${origin}, Preview Domain: ${previewDomain}`);
-
+                if (origin) {
+                    const previewDomain = getPreviewDomain(env);
+                    const originAllowed = isOriginAllowed(env, origin) || origin.endsWith(`.${previewDomain}`);
+                    if (!originAllowed) {
+                        logger.warn(`Access denied. Invalid origin: ${origin}, preview domain: ${previewDomain}`);
+                        return new Response('Access denied. Invalid origin.', { status: 403 });
+                    }
+                }
                 return proxyToAiGateway(request, env, ctx);
-				// if (origin && origin.endsWith(`.${previewDomain}`)) {
-                //     return proxyToAiGateway(request, env, ctx);
-                // }
-                // logger.warn(`Access denied. Invalid origin: ${origin}, preview domain: ${previewDomain}`);
-                // return new Response('Access denied. Invalid origin.', { status: 403 });
 			}
 
 			// Handle all API requests with the main Hono application.

--- a/worker/services/aigateway-proxy/controller.test.ts
+++ b/worker/services/aigateway-proxy/controller.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SignJWT } from 'jose';
+import { proxyToAiGateway, generateAppProxyToken } from './controller';
+
+// Mutable holder for the app row returned by the mocked DB query.
+const { state } = vi.hoisted(() => ({
+	state: { appRow: undefined as undefined | Record<string, unknown> },
+}));
+
+vi.mock('drizzle-orm/d1', () => ({
+	drizzle: () => ({
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					get: async () => state.appRow,
+				}),
+			}),
+		}),
+	}),
+}));
+
+vi.mock('../../agents/inferutils/core', () => ({
+	getConfigurationForModel: vi.fn(async () => ({
+		baseURL: 'https://gateway.example.com/v1',
+		apiKey: 'upstream-key',
+		defaultHeaders: {},
+	})),
+}));
+
+vi.mock('../rate-limit/rateLimits', () => ({
+	RateLimitService: { enforceLLMCallsRateLimit: vi.fn(async () => undefined) },
+}));
+
+vi.mock('worker/config', () => ({
+	getUserConfigurableSettings: vi.fn(async () => ({ security: { rateLimit: {} } })),
+}));
+
+const SECRET = 'test-ai-proxy-secret-0123456789abcdef';
+const AUDIENCE = 'vibesdk-ai-proxy';
+const ISSUER = 'vibesdk';
+
+const testEnv = {
+	AI_PROXY_JWT_SECRET: SECRET,
+	DB: {},
+} as unknown as Env;
+
+const ctx = {} as ExecutionContext;
+const URL_BASE = 'https://app.local/api/proxy/openai';
+
+function makeRequest(path: string, opts: { token?: string; body?: unknown; method?: string; rawBody?: string } = {}): Request {
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+	const body = opts.rawBody ?? (opts.body !== undefined ? JSON.stringify(opts.body) : undefined);
+	return new Request(`${URL_BASE}${path}`, {
+		method: opts.method ?? 'POST',
+		headers,
+		body,
+	});
+}
+
+async function signToken(payload: Record<string, unknown>, opts: { audience?: string; issuer?: string } = {}): Promise<string> {
+	let jwt = new SignJWT(payload).setProtectedHeader({ alg: 'HS256' }).setIssuedAt().setExpirationTime('1h');
+	if (opts.audience) jwt = jwt.setAudience(opts.audience);
+	if (opts.issuer) jwt = jwt.setIssuer(opts.issuer);
+	return jwt.sign(new TextEncoder().encode(SECRET));
+}
+
+const VALID_APP = { id: 'app-1', userId: 'user-1', title: 'My App', status: 'active' };
+
+describe('proxyToAiGateway', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		state.appRow = { ...VALID_APP };
+	});
+
+	it('rejects non-POST methods with 405', async () => {
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { method: 'GET' }), testEnv, ctx);
+		expect(res.status).toBe(405);
+	});
+
+	it('rejects requests without an Authorization header with 401', async () => {
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { body: { model: 'm' } }), testEnv, ctx);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects a token missing the required audience with 401', async () => {
+		const token = await signToken({ appId: 'app-1', userId: 'user-1', type: 'app-proxy' }, { issuer: ISSUER });
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, body: { model: 'm' } }), testEnv, ctx);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects a token with the wrong type with 401', async () => {
+		const token = await signToken({ appId: 'app-1', userId: 'user-1', type: 'other' }, { audience: AUDIENCE, issuer: ISSUER });
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, body: { model: 'm' } }), testEnv, ctx);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects a disallowed proxy path with 404', async () => {
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const res = await proxyToAiGateway(makeRequest('/admin/keys', { token, body: { model: 'm' } }), testEnv, ctx);
+		expect(res.status).toBe(404);
+	});
+
+	it('rejects an oversized body with 413', async () => {
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const rawBody = `{"model":"m","pad":"${'x'.repeat(5 * 1024 * 1024 + 100)}"}`;
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, rawBody }), testEnv, ctx);
+		expect(res.status).toBe(413);
+	});
+
+	it('rejects too many messages with 400', async () => {
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const messages = Array.from({ length: 201 }, () => ({ role: 'user', content: 'hi' }));
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, body: { model: 'm', messages } }), testEnv, ctx);
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects a request with no model with 400', async () => {
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, body: { messages: [] } }), testEnv, ctx);
+		expect(res.status).toBe(400);
+	});
+
+	it('clamps max_tokens and proxies the request', async () => {
+		const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const res = await proxyToAiGateway(
+			makeRequest('/chat/completions', { token, body: { model: 'm', max_tokens: 1_000_000, messages: [] } }),
+			testEnv,
+			ctx,
+		);
+
+		expect(res.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const forwarded = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+		expect(forwarded.max_tokens).toBe(16384);
+
+		vi.unstubAllGlobals();
+	});
+
+	it('returns 404 when the app is not found', async () => {
+		state.appRow = undefined;
+		const token = await generateAppProxyToken('app-1', 'user-1', testEnv);
+		const res = await proxyToAiGateway(makeRequest('/chat/completions', { token, body: { model: 'm' } }), testEnv, ctx);
+		expect(res.status).toBe(404);
+	});
+});

--- a/worker/services/aigateway-proxy/controller.ts
+++ b/worker/services/aigateway-proxy/controller.ts
@@ -8,6 +8,56 @@ import { RateLimitService } from '../rate-limit/rateLimits';
 import { getUserConfigurableSettings } from 'worker/config';
 import { AI_MODEL_CONFIG, AIModels } from 'worker/agents/inferutils/config.types';
 
+// Resource caps to protect the shared platform gateway from abuse (CWE-770).
+const MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MB total request body
+const MAX_MESSAGES = 200; // messages array length
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // total base64 image payload across messages
+const MAX_OUTPUT_TOKENS = 16384; // clamp for max_tokens / max_completion_tokens
+const UPSTREAM_TIMEOUT_MS = 120_000; // upstream fetch timeout
+
+// Only OpenAI-compatible inference endpoints may be reached through the proxy.
+const ALLOWED_PROXY_PATHS = new Set([
+    '/chat/completions',
+    '/completions',
+    '/embeddings',
+    '/responses',
+    '/models',
+]);
+
+// JWT scoping claims for app-proxy tokens.
+const AI_PROXY_AUDIENCE = 'vibesdk-ai-proxy';
+const AI_PROXY_ISSUER = 'vibesdk';
+
+function jsonError(status: number, message: string, type = 'invalid_request_error', extra?: Record<string, unknown>): Response {
+    return new Response(JSON.stringify({ error: { message, type, ...extra } }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+/**
+ * Sum the byte length of base64-encoded image payloads in an OpenAI-style
+ * messages array. Non-image content and remote image URLs are ignored.
+ */
+function countImageBytes(messages: unknown): number {
+    if (!Array.isArray(messages)) return 0;
+    let total = 0;
+    for (const message of messages) {
+        const content = (message as { content?: unknown } | null)?.content;
+        if (!Array.isArray(content)) continue;
+        for (const part of content) {
+            const url = (part as { image_url?: { url?: unknown } } | null)?.image_url?.url;
+            if (typeof url !== 'string') continue;
+            const commaIndex = url.indexOf(',');
+            if (url.startsWith('data:') && commaIndex !== -1) {
+                // base64 length -> decoded byte estimate
+                total += Math.floor((url.length - commaIndex - 1) * 3 / 4);
+            }
+        }
+    }
+    return total;
+}
+
 export async function proxyToAiGateway(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     console.log(`[AI Proxy] Received request: ${request.method} ${request.url}`);
     if (!env.AI_PROXY_JWT_SECRET) {
@@ -26,11 +76,24 @@ export async function proxyToAiGateway(request: Request, env: Env, _ctx: Executi
             status: 204,
             headers: {
                 'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+                'Access-Control-Allow-Methods': 'POST, OPTIONS',
                 'Access-Control-Allow-Headers': 'Content-Type, Authorization',
                 'Access-Control-Max-Age': '86400',
             },
         });
+    }
+
+    // The proxy only serves JSON inference requests, which are always POST.
+    if (request.method !== 'POST') {
+        return jsonError(405, 'Method not allowed', 'invalid_request_error');
+    }
+
+    // Reject oversized bodies up front via Content-Length; the actual byte
+    // length is re-checked after reading to defend against a missing or
+    // spoofed header.
+    const contentLength = Number(request.headers.get('Content-Length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+        return jsonError(413, 'Request body too large', 'invalid_request_error');
     }
 
     try {
@@ -58,8 +121,15 @@ export async function proxyToAiGateway(request: Request, env: Env, _ctx: Executi
         let userId: string;
         try {
             const jwtSecret = new TextEncoder().encode(env.AI_PROXY_JWT_SECRET);
-            const { payload } = await jwtVerify(token, jwtSecret);
-            
+            const { payload } = await jwtVerify(token, jwtSecret, {
+                audience: AI_PROXY_AUDIENCE,
+                issuer: AI_PROXY_ISSUER,
+            });
+
+            if (payload.type !== 'app-proxy') {
+                return jsonError(401, 'Invalid token: wrong token type', 'invalid_request_error');
+            }
+
             if (!payload.appId || typeof payload.appId !== 'string') {
                 return new Response(JSON.stringify({ 
                     error: { message: 'Invalid token: missing appId', type: 'invalid_request_error' } 
@@ -124,23 +194,54 @@ export async function proxyToAiGateway(request: Request, env: Env, _ctx: Executi
         console.log(`[AI Proxy] Authenticated request from app: ${app.title} (${app.id}), user: ${app.userId}`);
 
         const url = new URL(request.url);
-        const requestBody = await request.json() as {
-            model: string;
-            [key: string]: unknown;
-        };
+
+        // Only allow OpenAI-compatible inference endpoints through the proxy.
+        const targetPath = url.pathname.replace('/api/proxy/openai', '');
+        if (!ALLOWED_PROXY_PATHS.has(targetPath)) {
+            return jsonError(404, `Unsupported proxy path: ${targetPath}`, 'invalid_request_error');
+        }
+
+        // Read the raw body and enforce the byte cap against the actual payload,
+        // not just the (optional/spoofable) Content-Length header.
+        const rawBody = await request.text();
+        if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+            return jsonError(413, 'Request body too large', 'invalid_request_error');
+        }
+
+        let requestBody: { model: string; [key: string]: unknown };
+        try {
+            requestBody = JSON.parse(rawBody) as { model: string; [key: string]: unknown };
+        } catch {
+            return jsonError(400, 'Invalid JSON body', 'invalid_request_error');
+        }
 
         if (!requestBody.model || typeof requestBody.model !== 'string') {
-            return new Response(JSON.stringify({ 
-                error: { 
-                    message: 'Missing required parameter: model',
-                    type: 'invalid_request_error',
-                    param: 'model',
-                    code: 'missing_required_parameter'
-                } 
-            }), { 
-                status: 400, 
-                headers: { 'Content-Type': 'application/json' } 
+            return jsonError(400, 'Missing required parameter: model', 'invalid_request_error', {
+                param: 'model',
+                code: 'missing_required_parameter',
             });
+        }
+
+        // Cap the number of messages and the total inline image payload.
+        if (requestBody.messages !== undefined) {
+            if (!Array.isArray(requestBody.messages)) {
+                return jsonError(400, 'Invalid parameter: messages must be an array', 'invalid_request_error', { param: 'messages' });
+            }
+            if (requestBody.messages.length > MAX_MESSAGES) {
+                return jsonError(400, `Too many messages (max ${MAX_MESSAGES})`, 'invalid_request_error', { param: 'messages' });
+            }
+            if (countImageBytes(requestBody.messages) > MAX_IMAGE_BYTES) {
+                return jsonError(413, 'Inline image payload too large', 'invalid_request_error');
+            }
+        }
+
+        // Clamp the requested output tokens so a single call cannot exhaust the
+        // platform budget. Rewritten in place rather than rejected.
+        for (const key of ['max_tokens', 'max_completion_tokens'] as const) {
+            const value = requestBody[key];
+            if (typeof value === 'number' && value > MAX_OUTPUT_TOKENS) {
+                requestBody[key] = MAX_OUTPUT_TOKENS;
+            }
         }
 
         const modelName = requestBody.model;
@@ -177,16 +278,25 @@ export async function proxyToAiGateway(request: Request, env: Env, _ctx: Executi
             model: modelName
         }));
 
-        const targetPath = url.pathname.replace('/api/proxy/openai', '');
         const targetUrl = `${baseURL}${targetPath}${url.search}`;
 
         console.log(`[AI Proxy] Target URL: ${targetUrl}`);
 
-        const proxyResponse = await fetch(targetUrl, {
-            method: request.method,
-            headers: proxyHeaders,
-            body: JSON.stringify(requestBody),
-        });
+        let proxyResponse: Response;
+        try {
+            proxyResponse = await fetch(targetUrl, {
+                method: request.method,
+                headers: proxyHeaders,
+                body: JSON.stringify(requestBody),
+                signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+            });
+        } catch (error) {
+            if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+                console.error('[AI Proxy] Upstream request timed out');
+                return jsonError(504, 'Upstream request timed out', 'timeout_error');
+            }
+            throw error;
+        }
 
         // Allowlist response headers to avoid leaking upstream cookies, cf-aig-* metadata,
         // or any Cloudflare-internal auth headers back to the caller.
@@ -245,6 +355,8 @@ export async function generateAppProxyToken(
     })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt(now)
+    .setIssuer(AI_PROXY_ISSUER)
+    .setAudience(AI_PROXY_AUDIENCE)
     .setExpirationTime(now + expiresInSeconds)
     .sign(jwtSecret);
     


### PR DESCRIPTION
The /api/proxy/openai proxy forwarded arbitrary OpenAI-compatible JSON with no body limit, no message/image/max_tokens caps, no path allowlist, no upstream timeout, and only signature-level JWT checks, letting any valid app-proxy token exhaust the shared platform AI budget.

Add request caps (body bytes, message count, inline image bytes), clamp max_tokens, allowlist inference paths, add an upstream fetch timeout, and verify JWT audience/issuer/type. Re-enable an enforce-if-present origin gate on the proxy route.