### PR TITLE
chore: document Node.js 22+ requirement and enforce via engines

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -71,7 +71,7 @@
 ### **Running Locally**
 
 **Prerequisites:**
-- Node.js 18+
+- Node.js 22+
 - Cloudflare account (for D1, Durable Objects)
 - API keys: OpenAI, Anthropic, Google AI Studio
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,7 +11,7 @@ Local first time setup guide for VibSDK - get your AI coding platform running lo
 Before getting started, make sure you have:
 
 ### Required
-- **Node.js** (v18 or later)
+- **Node.js** (v22 or later)
 - **Cloudflare account** with API access  
 - **Cloudflare API Token** with appropriate permissions
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"private": true,
 	"version": "1.5.0",
 	"type": "module",
+	"engines": {
+		"node": ">=22"
+	},
 	"workspaces": [
 		"space"
 	],

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -2119,7 +2119,12 @@ async function main() {
 	await setup.setup();
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run if this is the main module (supports both direct execution and tsx)
+const isMainModule = import.meta.url.endsWith('setup.ts') ||
+	import.meta.url === `file://${process.argv[1]}` ||
+	process.argv[1]?.endsWith('setup.ts');
+
+if (isMainModule) {
 	main().catch((error) => {
 		console.error('Setup failed:', error);
 		process.exit(1);


### PR DESCRIPTION
## Summary

Document and enforce the Node.js 22+ minimum the codebase actually targets.

The project already pins Node 22 in CI (`node-version: 22`) and uses `@types/node ^22.19.3`, but the documented prerequisite still said "Node.js v18 or later" with no `engines` field in `package.json`. This PR closes that gap.

This bundles the long-stale fix proposed in #236 (zzy-life/vibesdk2) plus the missing enforcement.

## Changes

- `docs/setup.md`: bump Node.js prerequisite from `v18 or later` → `v22 or later`.
- `docs/llm.md`: same bump in the Local Running prerequisites section.
- `package.json`: add `"engines": { "node": ">=22" }` so `npm`/`bun` warn on install instead of silently allowing Node 18.
- `scripts/setup.ts`: loosen the main-module check so `tsx scripts/setup.ts` triggers `main()`. The previous strict `import.meta.url === file://process.argv[1]` check fails under tsx because the resolved URL no longer matches. Mirrors the fix from #236.

## Why now

- `engines.node` aligns the runtime contract with the rest of the toolchain.
- The `setup.ts` tsx fix has been stuck in a fork for 9 months; pulling it in unblocks Windows users (the original report) and anyone running setup through `npx tsx` or similar wrappers.

## Test plan

- [ ] `node --version` reports `v22.x` on a fresh checkout.
- [ ] `bun install` (or `npm install`) prints an engines warning on Node 20 or below.
- [ ] `bun run setup` (or `npx tsx scripts/setup.ts`) reaches the `main()` entry point.
- [ ] All four files diffed cleanly against `origin/main`.