### PR TITLE
fix: expose artifacts setting as a worker variable

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -3,9 +3,6 @@
 #ENVIRONMENT="prod" # Options: dev, staging, prod
 
 # Feature flags
-# Cloudflare Artifacts filesystem backend for SpaceDO. This feature is in closed beta;
-# enable it only if Cloudflare has granted your account access.
-ENABLE_ARTIFACTS="false"
 
 # Cloudflare Credentials (Required for manual deployment via `bun run deploy`)
 # These are automatically provided when using "Deploy to Cloudflare" button

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -224,6 +224,8 @@
             "version": "1.0.0"
         },
         "CUSTOM_DOMAIN": "",
+        // Cloudflare Artifacts is in closed beta; enable only for accounts with access.
+        "ENABLE_ARTIFACTS": "false",
         "MAX_SANDBOX_INSTANCES": "10",
         "SANDBOX_INSTANCE_TYPE": "standard-3",
         "DEV_BROWSER_SIDECAR_URL": "http://127.0.0.1:9223",


### PR DESCRIPTION
Keep the closed beta setting visible in Wrangler instead of collecting it as a deploy secret.