### PR TITLE
fix: add noopener,noreferrer to _blank targets to prevent reverse tab…

### DIFF
--- a/src/components/auth/login-modal.tsx
+++ b/src/components/auth/login-modal.tsx
@@ -507,6 +507,7 @@ export function LoginModal({
 						<a
 							href="https://www.cloudflare.com/website-terms/"
 							target="_blank"
+							rel="noopener noreferrer"
 							className="underline hover:text-kumo-default"
 						>
 							Terms of Service
@@ -515,6 +516,7 @@ export function LoginModal({
 						<a
 							href="https://www.cloudflare.com/privacypolicy/"
 							target="_blank"
+							rel="noopener noreferrer"
 							className="underline hover:text-kumo-default"
 						>
 							Privacy Policy

--- a/src/components/cloudflare-account-selector.tsx
+++ b/src/components/cloudflare-account-selector.tsx
@@ -310,7 +310,7 @@ export function CloudflareAccountSelector() {
 								<DropdownMenu.Content align="end">
 									{gatewayDashUrl && (
 										<DropdownMenu.Item
-											onClick={() => window.open(gatewayDashUrl, '_blank')}
+											onClick={() => window.open(gatewayDashUrl, '_blank', 'noopener,noreferrer')}
 										>
 											<ExternalLink className="size-4" />
 											View gateway

--- a/src/features/presentation/components/PresentationHeaderActions.tsx
+++ b/src/features/presentation/components/PresentationHeaderActions.tsx
@@ -48,7 +48,7 @@ export function PresentationHeaderActions({
 			: `${currentSrc}?print-pdf`;
 
 		// Open print view in new window for PDF export
-		window.open(printUrl, '_blank');
+		window.open(printUrl, '_blank', 'noopener,noreferrer');
 	};
 
 	return (

--- a/src/routes/app/index.tsx
+++ b/src/routes/app/index.tsx
@@ -792,7 +792,7 @@ export default function AppView() {
 											aria-label="Open in new tab"
 											title="Open in new tab"
 											onClick={() =>
-												window.open(appUrl, '_blank')
+												window.open(appUrl, '_blank', 'noopener,noreferrer')
 											}
 											icon={
 												<ExternalLink className="size-3.5" />

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -409,7 +409,7 @@ function ChatSession() {
 								<Button
 									variant="ghost"
 									className="h-8 shrink-0 px-2 text-xs text-text-tertiary hover:bg-kumo-elevated hover:text-text-primary"
-									onClick={() => window.open(cloudflareDeploymentUrl, '_blank')}
+									onClick={() => window.open(cloudflareDeploymentUrl, '_blank', 'noopener,noreferrer')}
 								>
 									<ExternalLink className="size-3.5" />
 									View Live

--- a/src/routes/chat/components/deployment-controls.tsx
+++ b/src/routes/chat/components/deployment-controls.tsx
@@ -123,7 +123,7 @@ export function DeploymentControls({
 
 		// Public apps (or missing appId): open the deployed URL directly.
 		if (deploymentTarget === 'user' || localVisibility !== 'private' || !appId) {
-			window.open(deploymentUrl, '_blank');
+			window.open(deploymentUrl, '_blank', 'noopener,noreferrer');
 			return;
 		}
 
@@ -132,7 +132,7 @@ export function DeploymentControls({
 		try {
 			const response = await apiClient.generatePreviewToken(appId);
 			if (response.success && response.data) {
-				window.open(response.data.previewUrl, '_blank');
+				window.open(response.data.previewUrl, '_blank', 'noopener,noreferrer');
 				return;
 			}
 		} catch (error) {
@@ -140,7 +140,7 @@ export function DeploymentControls({
 		}
 
 		// Fallback: attempt the raw URL.
-		window.open(deploymentUrl, '_blank');
+		window.open(deploymentUrl, '_blank', 'noopener,noreferrer');
 	};
 
 	const handleToggleVisibility = async () => {

--- a/src/utils/usage-limit-checker.tsx
+++ b/src/utils/usage-limit-checker.tsx
@@ -156,7 +156,7 @@ function createInsufficientBalanceDialog(balance: number, accountId: string | un
 							const url = accountId 
 								? `https://dash.cloudflare.com/${accountId}/ai/ai-gateway/credits`
 								: 'https://dash.cloudflare.com';
-							window.open(url, '_blank');
+							window.open(url, '_blank', 'noopener,noreferrer');
 						}}
 						className="w-full sm:w-auto bg-brand-primary hover:bg-brand-primary/90 text-white"
 					>


### PR DESCRIPTION
…nabbing

Opening attacker-influenced app/preview URLs in a new tab without noopener leaves a live window.opener handle to the platform tab, enabling reverse tabnabbing (CWE-1022). Add noopener,noreferrer to all window.open('_blank') calls and rel=noopener noreferrer to target=_blank anchors that were missing it.