### PR TITLE
fix(security): strip browser credentials at sandbox proxy and redact …

### DIFF
--- a/worker/api/handlers/git-protocol.ts
+++ b/worker/api/handlers/git-protocol.ts
@@ -106,13 +106,6 @@ async function verifyGitAccess(
 ): Promise<{ hasAccess: boolean; appCreatedAt?: Date }> {
     logger.info('Verifying git access', { appId });
     
-    // Log all headers for debugging
-    const headers: Record<string, string> = {};
-    request.headers.forEach((value, key) => {
-        headers[key] = key.toLowerCase().includes('auth') ? `${value.substring(0, 20)}...` : value;
-    });
-    logger.info('Request headers', { headers, url: request.url });
-    
     const appService = new AppService(env);
     const app = await appService.getAppDetails(appId);
     

--- a/worker/services/sandbox/request-handler.test.ts
+++ b/worker/services/sandbox/request-handler.test.ts
@@ -65,6 +65,71 @@ describe('proxyToSandbox', () => {
 		expect(containerFetch).not.toHaveBeenCalled();
 	});
 
+	it('strips Cookie/Authorization but forwards safe headers to the container', async () => {
+		validatePortToken.mockResolvedValue(true);
+		containerFetch.mockResolvedValue(new Response('ok'));
+
+		await proxyToSandbox(
+			req(`8001-mysandbox-${TOKEN}.preview.example.dev`, {
+				headers: {
+					Cookie: 'session=secret',
+					Authorization: 'Bearer secret',
+					'X-Csrf-Token': 'secret',
+					'X-Api-Key': 'secret',
+					Accept: 'text/html',
+					'Content-Type': 'application/json',
+				},
+			}),
+			env,
+		);
+
+		const proxied = containerFetch.mock.calls[0][0] as Request;
+		expect(proxied.headers.get('Cookie')).toBeNull();
+		expect(proxied.headers.get('Authorization')).toBeNull();
+		expect(proxied.headers.get('X-Csrf-Token')).toBeNull();
+		expect(proxied.headers.get('X-Api-Key')).toBeNull();
+		expect(proxied.headers.get('Accept')).toBe('text/html');
+		expect(proxied.headers.get('Content-Type')).toBe('application/json');
+	});
+
+	it('adds proxy X-* headers on the container request', async () => {
+		validatePortToken.mockResolvedValue(true);
+		containerFetch.mockResolvedValue(new Response('ok'));
+
+		await proxyToSandbox(req(`8001-mysandbox-${TOKEN}.preview.example.dev`), env);
+
+		const proxied = containerFetch.mock.calls[0][0] as Request;
+		expect(proxied.headers.get('X-Sandbox-Name')).toBe('mysandbox');
+		expect(proxied.headers.get('X-Forwarded-Host')).toBe(
+			`8001-mysandbox-${TOKEN}.preview.example.dev`,
+		);
+		expect(proxied.headers.get('X-Forwarded-Proto')).toBe('https');
+	});
+
+	it('forwards WebSocket handshake headers but strips Cookie on a valid upgrade', async () => {
+		validatePortToken.mockResolvedValue(true);
+		sandboxFetch.mockResolvedValue(new Response('ok'));
+
+		await proxyToSandbox(
+			req(`8001-mysandbox-${TOKEN}.preview.example.dev`, {
+				headers: {
+					Upgrade: 'websocket',
+					Connection: 'Upgrade',
+					'Sec-WebSocket-Version': '13',
+					Cookie: 'session=secret',
+					Authorization: 'Bearer secret',
+				},
+			}),
+			env,
+		);
+
+		const forwarded = sandboxFetch.mock.calls[0][0] as Request;
+		expect(forwarded.headers.get('Upgrade')).toBe('websocket');
+		expect(forwarded.headers.get('Sec-WebSocket-Version')).toBe('13');
+		expect(forwarded.headers.get('Cookie')).toBeNull();
+		expect(forwarded.headers.get('Authorization')).toBeNull();
+	});
+
 	it('rejects a WebSocket upgrade with a bad token (no sandbox.fetch)', async () => {
 		validatePortToken.mockResolvedValue(false);
 

--- a/worker/services/sandbox/request-handler.ts
+++ b/worker/services/sandbox/request-handler.ts
@@ -30,6 +30,66 @@ export interface RouteInfo {
  */
 const CONTROL_PLANE_PORTS = new Set<number>([3000, 8787]);
 
+/**
+ * Strict allowlist of request headers forwarded from the browser into the
+ * (untrusted) container. The container runs LLM-generated code, so the proxy
+ * must never pass first-party platform credentials across this trust boundary.
+ * Anything not listed here is dropped — in particular Cookie, Authorization,
+ * X-CSRF-Token, X-Session-*, and X-Api-Key.
+ */
+const FORWARDED_REQUEST_HEADERS = new Set<string>([
+  'accept',
+  'accept-language',
+  'accept-encoding',
+  'content-type',
+  'content-length',
+  'user-agent',
+  'range',
+  'if-none-match',
+  'if-modified-since',
+  'cache-control',
+  'pragma',
+  'referer',
+  'origin',
+]);
+
+/**
+ * Additional headers required to complete a WebSocket handshake. These carry no
+ * credentials and must survive the allowlist so upgrades still work.
+ * `cf-container-target-port` is what `switchPort` uses to route to the port.
+ */
+const WEBSOCKET_HANDSHAKE_HEADERS = new Set<string>([
+  'upgrade',
+  'connection',
+  'sec-websocket-key',
+  'sec-websocket-version',
+  'sec-websocket-protocol',
+  'sec-websocket-extensions',
+  'cf-container-target-port',
+]);
+
+/**
+ * Build the outbound header set from the incoming request using the strict
+ * allowlist, then layer on the proxy-added headers in `extra`.
+ */
+function buildProxyHeaders(
+  request: Request,
+  extra: Record<string, string>,
+  allowExtra?: ReadonlySet<string>,
+): Headers {
+  const headers = new Headers();
+  request.headers.forEach((value, name) => {
+    const lower = name.toLowerCase();
+    if (FORWARDED_REQUEST_HEADERS.has(lower) || allowExtra?.has(lower)) {
+      headers.set(name, value);
+    }
+  });
+  for (const [name, value] of Object.entries(extra)) {
+    headers.set(name, value);
+  }
+  return headers;
+}
+
 export async function proxyToSandbox<E extends SandboxEnv>(
   request: Request,
   env: E
@@ -69,8 +129,14 @@ export async function proxyToSandbox<E extends SandboxEnv>(
     if (upgradeHeader?.toLowerCase() === 'websocket') {
       logger.info('[Proxy] WebSocket upgrade request', { sandboxId, port, path });
       // WebSocket path: Must use fetch() not containerFetch()
-      // This bypasses JSRPC serialization boundary which cannot handle WebSocket upgrades
-      return await sandbox.fetch(switchPort(request, port));
+      // This bypasses JSRPC serialization boundary which cannot handle WebSocket upgrades.
+      // Strip credentials while preserving the handshake + port-target headers.
+      const wsRequest = switchPort(request, port);
+      return await sandbox.fetch(
+        new Request(wsRequest, {
+          headers: buildProxyHeaders(wsRequest, {}, WEBSOCKET_HANDSHAKE_HEADERS),
+        }),
+      );
     }
 
     // Route directly to user's service on the specified port
@@ -78,13 +144,12 @@ export async function proxyToSandbox<E extends SandboxEnv>(
 
     const proxyRequest = new Request(proxyUrl, {
       method: request.method,
-      headers: {
-        ...Object.fromEntries(request.headers),
+      headers: buildProxyHeaders(request, {
         'X-Original-URL': request.url,
         'X-Forwarded-Host': url.hostname,
         'X-Forwarded-Proto': url.protocol.replace(':', ''),
-        'X-Sandbox-Name': sandboxId // Pass the friendly name
-      },
+        'X-Sandbox-Name': sandboxId, // Pass the friendly name
+      }),
       body: request.body,
       // @ts-expect-error - duplex required for body streaming in modern runtimes
       duplex: 'half',


### PR DESCRIPTION
…git logs

The sandbox preview proxy forwarded every incoming request header into untrusted container code, leaking first-party Cookie/Authorization credentials across the platform-to-container trust boundary. Replace the blanket header spread with a strict allowlist on both the HTTP and WebSocket paths, preserving only safe content/negotiation headers (and the WebSocket handshake + port-target headers) while dropping Cookie, Authorization, X-CSRF-Token, X-Session-*, and X-Api-Key.

Also remove the git protocol handler's debug log that dumped all request headers and leaked the first 20 chars of the Authorization bearer token.