### PR TITLE
feat: add OrcaRouter as a named model provider

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -28,8 +28,9 @@
 #ANTHROPIC_API_KEY=""
 #OPENAI_API_KEY=""
 #GOOGLE_AI_STUDIO_API_KEY=""
-#OPENROUTER_API_KEY="default" 
-#GROQ_API_KEY="default" 
+#OPENROUTER_API_KEY="default"
+#ORCAROUTER_API_KEY="default"
+#GROQ_API_KEY="default"
  
 # Stuff for Oauths:
 #GOOGLE_CLIENT_SECRET=""

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -110,7 +110,8 @@ The setup script offers multiple AI providers with intelligent multi-selection:
 3. **Google AI Studio** (for Gemini models) - **Default & Recommended**
 4. **Cerebras** (for open source models)
 5. **OpenRouter** (for various models)
-6. **Custom provider** (for any other provider)
+6. **OrcaRouter** (150+ models through one key)
+7. **Custom provider** (for any other provider)
 
 **Provider Selection:**
 - Select multiple providers with comma-separated numbers (e.g., `1,2,3`)

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -374,10 +374,11 @@ class SetupManager {
 		console.log('   3. Google AI Studio (for Gemini models) [DEFAULT]');
 		console.log('   4. Cerebras (for open source models)');
 		console.log('   5. OpenRouter (for various models)');
-		console.log('   6. Custom provider\n');
+		console.log('   6. OrcaRouter (150+ models, one key)');
+		console.log('   7. Custom provider\n');
 
 		const providerChoice = await this.prompt('Select providers (comma-separated numbers, e.g., 1,2,3): ');
-		const selectedProviders = providerChoice.split(',').map(n => parseInt(n.trim())).filter(n => n >= 1 && n <= 6);
+		const selectedProviders = providerChoice.split(',').map(n => parseInt(n.trim())).filter(n => n >= 1 && n <= 7);
 
 		if (selectedProviders.length === 0) {
 			console.log('⚠️  No providers selected - you MUST configure at least one provider!');
@@ -396,7 +397,7 @@ class SetupManager {
 
 		console.log('\n🔑 API Key Configuration');
 		for (const choice of selectedProviders) {
-			if (choice === 6) {
+			if (choice === 7) {
 				// Custom provider
 				const customProviderName = await this.prompt('Enter custom provider name: ');
 				if (customProviderName) {

--- a/worker/agents/inferutils/config.types.ts
+++ b/worker/agents/inferutils/config.types.ts
@@ -337,6 +337,18 @@ const MODELS_MASTER = {
             creditCost: 8, // $0.22
             contextSize: 262144, // 256K Context
         },
+    },
+    // --- OrcaRouter Models (direct-override OpenAI-compatible gateway) ---
+    ORCAROUTER_AUTO: {
+        id: 'orcarouter/auto',
+        config: {
+            name: 'OrcaRouter Auto',
+            size: ModelSize.REGULAR,
+            provider: 'orcarouter',
+            creditCost: 2, // ~$0.50
+            contextSize: 200000, // 200K Context
+            directOverride: true,
+        },
     }
 } as const;
 

--- a/worker/agents/inferutils/core.test.ts
+++ b/worker/agents/inferutils/core.test.ts
@@ -98,6 +98,28 @@ describe('getConfigurationForModel - gateway/key coupling', () => {
 	});
 });
 
+describe('getConfigurationForModel - directOverride providers', () => {
+	const ORCAROUTER_MODEL: AIModelConfig = {
+		name: 'OrcaRouter Auto',
+		size: ModelSize.REGULAR,
+		provider: 'orcarouter',
+		creditCost: 2,
+		contextSize: 200_000,
+		directOverride: true,
+	};
+
+	it('routes orcarouter direct-override models to the OrcaRouter gateway with ORCAROUTER_API_KEY', async () => {
+		const { apiKey, baseURL } = await getConfigurationForModel(
+			ORCAROUTER_MODEL,
+			makeEnv({ ORCAROUTER_API_KEY: 'sk-orca-valid-orca-key-1234567890' }),
+			'user-1',
+		);
+
+		expect(baseURL).toBe('https://api.orcarouter.ai/v1');
+		expect(apiKey).toBe('sk-orca-valid-orca-key-1234567890');
+	});
+});
+
 describe('credentialsToRuntimeOverrides - baseUrl validation', () => {
 	it('drops a non-https gateway baseUrl', () => {
 		const result = credentialsToRuntimeOverrides({

--- a/worker/agents/inferutils/core.ts
+++ b/worker/agents/inferutils/core.ts
@@ -445,6 +445,11 @@ export async function getConfigurationForModel(
                     baseURL: 'https://openrouter.ai/api/v1',
                     apiKey: env.OPENROUTER_API_KEY,
                 };
+            case 'orcarouter':
+                return {
+                    baseURL: 'https://api.orcarouter.ai/v1',
+                    apiKey: env.ORCAROUTER_API_KEY,
+                };
             case 'google-ai-studio':
                 return {
                     baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',

--- a/worker/api/controllers/modelConfig/byokHelper.ts
+++ b/worker/api/controllers/modelConfig/byokHelper.ts
@@ -53,6 +53,7 @@ export function getPlatformEnabledProviders(env: Env): string[] {
 		'google-ai-studio',
 		'cerebras',
 		'groq',
+		'orcarouter',
 	];
 
 	for (const provider of providerList) {

--- a/worker/database/services/ModelTestService.ts
+++ b/worker/database/services/ModelTestService.ts
@@ -182,6 +182,7 @@ export class ModelTestService extends BaseService {
             'gemini': AIModels.GEMINI_2_5_FLASH,
             // 'openrouter': AIModels.OPENROUTER_QWEN_3_CODER, // Removed - not available
             // 'cerebras': AIModels.CEREBRAS_GPT_OSS
+            'orcarouter': AIModels.ORCAROUTER_AUTO,
         };
 
         return testModels[provider] || null;

--- a/worker/types/env.d.ts
+++ b/worker/types/env.d.ts
@@ -24,6 +24,7 @@ declare namespace Cloudflare {
 		GITHUB_CLIENT_ID: string;
 		GITHUB_CLIENT_SECRET: string;
 		OPENROUTER_API_KEY: string;
+		ORCAROUTER_API_KEY: string;
 		PLATFORM_MODEL_PROVIDERS: string;
 		SANDBOX_SERVICE_API_KEY: string;
 		SANDBOX_SERVICE_TYPE: string;

--- a/worker/types/secretsTemplates.ts
+++ b/worker/types/secretsTemplates.ts
@@ -101,6 +101,19 @@ export function getTemplatesData(): SecretTemplate[] {
 			required: false,
 			category: 'ai',
 		},
+		{
+			id: 'ORCAROUTER_API_KEY',
+			displayName: 'OrcaRouter API Key',
+			envVarName: 'ORCAROUTER_API_KEY',
+			provider: 'orcarouter',
+			icon: '🐋',
+			description: 'OrcaRouter API key for 150+ models through one gateway',
+			instructions: 'Go to OrcaRouter → Account → API Keys → Create new key',
+			placeholder: 'sk-orca-...',
+			validation: '^sk-orca-[a-zA-Z0-9_-]{20,}$',
+			required: false,
+			category: 'ai',
+		},
 
 		// BYOK (Bring Your Own Key) AI Providers - Lenient validation for compatibility
 		{


### PR DESCRIPTION
## Summary

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

OrcaRouter joins the same direct-override path the codebase already defines for `openrouter` (`getConfigurationForModel`), so the model picker, provider list, secrets, and docs stay consistent.

## Changes

- `worker/agents/inferutils/config.types.ts`: add `ORCAROUTER_AUTO` (`orcarouter/auto`) to `MODELS_MASTER` as a `directOverride` model.
- `worker/agents/inferutils/core.ts`: add `case 'orcarouter'` to the direct-override switch → `baseURL https://api.orcarouter.ai/v1`, key from `ORCAROUTER_API_KEY` (keys start with `sk-orca-`).
- `worker/types/env.d.ts`: declare `ORCAROUTER_API_KEY`.
- `.dev.vars.example`: document `ORCAROUTER_API_KEY`.
- `worker/types/secretsTemplates.ts`: add an OrcaRouter API key template (vault).
- `worker/api/controllers/modelConfig/byokHelper.ts`: recognize `orcarouter` as an env-key-enabled platform provider so the model shows in the picker.
- `worker/database/services/ModelTestService.ts`: map `orcarouter` → `orcarouter/auto` for provider connection tests.
- `scripts/setup.ts` + `docs/setup.md`: add OrcaRouter to the setup provider selection list.
- `worker/agents/inferutils/core.test.ts`: add a direct-override test asserting the OrcaRouter base URL and key.

## Testing

- `bunx vitest run worker/agents/inferutils/core.test.ts` — 8 passed (includes the new OrcaRouter direct-override case).
- `bun run typecheck` — passed (`tsc -b --incremental --noEmit`).
- `bun run lint` — 0 errors (2 pre-existing warnings in `src/components/layout/header-context.tsx`).
- L3 live test with a real key through the exact provider wire path (`GET /v1/models` + `POST /v1/chat/completions` with `orcarouter/auto`, Bearer key) → 200, routed upstream, response received.

I'm an engineer on the OrcaRouter team.
