### PR TITLE
fix(sdk): apply file_deleted to workspace and file events

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -177,6 +177,7 @@ export type AgentEventMap = {
 		| 'file_generating'
 		| 'file_regenerating'
 		| 'file_regenerated'
+		| 'file_deleted'
 	>;
 	generation: WsMessageOf<'generation_started' | 'generation_complete' | 'generation_stopped' | 'generation_resumed'>;
 	preview: WsMessageOf<'deployment_completed' | 'deployment_started' | 'deployment_failed'>;

--- a/sdk/src/workspace.ts
+++ b/sdk/src/workspace.ts
@@ -75,6 +75,12 @@ export class WorkspaceStore {
 		this.emitter.emit('change', { type: 'upsert', path: f.path });
 	}
 
+	/** Apply a file_deleted event (same path the FE removes from the editor list). */
+	applyFileDelete(path: string): void {
+		this.files.delete(path);
+		this.emitter.emit('change', { type: 'delete', path });
+	}
+
 	applyWsMessage(msg: AgentWsServerMessage): void {
 		switch (msg.type) {
 			case 'agent_connected':
@@ -88,6 +94,9 @@ export class WorkspaceStore {
 				break;
 			case 'file_regenerated':
 				this.applyFileUpsert(msg.file);
+				break;
+			case 'file_deleted':
+				this.applyFileDelete(msg.filePath);
 				break;
 			default:
 				break;

--- a/sdk/src/ws.ts
+++ b/sdk/src/ws.ts
@@ -168,6 +168,7 @@ export function createAgentConnection(
 				case 'file_generating':
 				case 'file_regenerating':
 				case 'file_regenerated':
+				case 'file_deleted':
 					emitter.emit('file', parsed);
 					break;
 				case 'generation_started':

--- a/sdk/test/workspace.test.ts
+++ b/sdk/test/workspace.test.ts
@@ -29,4 +29,15 @@ describe('WorkspaceStore', () => {
 		ws.applyWsMessage({ type: 'file_generated', file: { filePath: 'src/x.ts', fileContents: '1' } } as any);
 		expect(ws.read('src/x.ts')).toBe('1');
 	});
+
+	it('applies file_deleted and emits delete', () => {
+		const ws = new WorkspaceStore();
+		const changes: Array<{ type: string; path?: string }> = [];
+		ws.onChange((c) => changes.push(c));
+		ws.applyWsMessage({ type: 'file_generated', file: { filePath: 'src/gone.ts', fileContents: 'bye' } } as any);
+		ws.applyWsMessage({ type: 'file_deleted', filePath: 'src/gone.ts' } as any);
+		expect(ws.read('src/gone.ts')).toBe(null);
+		expect(ws.paths()).toEqual([]);
+		expect(changes.some((c) => c.type === 'delete' && c.path === 'src/gone.ts')).toBe(true);
+	});
 });

--- a/sdk/test/ws-routing.test.ts
+++ b/sdk/test/ws-routing.test.ts
@@ -42,6 +42,28 @@ describe('createAgentConnection', () => {
 		conn.close();
 	});
 
+	it('routes file_deleted into the file sugar event', async () => {
+		const conn = createAgentConnection(async () => {
+			const resp = await fetch(`${server.url}/api/ws-ticket`, { method: 'POST' });
+			const { data } = await resp.json() as { data: { ticket: string } };
+			return `${server.wsUrl}?ticket=${data.ticket}`;
+		});
+
+		await waitForClients(server, 1);
+
+		let fileCount = 0;
+		conn.on('file', () => {
+			fileCount += 1;
+		});
+
+		server.broadcast({ type: 'file_deleted', filePath: 'src/gone.ts' });
+		await new Promise((r) => setTimeout(r, 100));
+
+		expect(fileCount).toBe(1);
+
+		conn.close();
+	});
+
 	it('emits ws:open and connected events', async () => {
 		let openCount = 0;
 		let connectedCount = 0;


### PR DESCRIPTION
## Problem

When the think agent deletes a file, the Worker broadcasts `file_deleted` and the chat UI removes it from the editor list. The public TypeScript SDK does not:

- `WorkspaceStore.applyWsMessage` handles `file_generated` / `file_regenerated` but ignores `file_deleted`, so `session.files` still lists the path.
- `createAgentConnection` does not route `file_deleted` to the `file` sugar event (sibling of `file_generated`).
- The SDK README documents `workspace.onChange` as `'upsert' | 'delete' | 'reset'`, but `delete` was never emitted.

## Fix

- Apply `file_deleted` in `WorkspaceStore` (remove path, emit `{ type: 'delete', path }`).
- Route `file_deleted` through the existing `file` event channel and include it in `AgentEventMap['file']`.

Does not change `conversation_cleared` or other unhandled server types.

## Testing

```bash
bun run --cwd sdk test
```

New cases: `WorkspaceStore` file_deleted; `createAgentConnection` routes `file_deleted` to `file`.
