### PR TITLE
fix(security): scope git clone tokens to their exact app repository

### DIFF
--- a/worker/agents/index.ts
+++ b/worker/agents/index.ts
@@ -12,6 +12,7 @@ import { BaseSandboxService } from 'worker/services/sandbox/BaseSandboxService';
 import { AgentState, CurrentDevState } from './core/state';
 import { CodeGeneratorAgent } from './core/codingAgent';
 import { BehaviorType, ProjectType } from './core/types';
+import type { GitCloneRepositoryTarget } from '../utils/gitCloneToken';
 
 type AgentStubProps = {
     behaviorType?: BehaviorType;
@@ -55,11 +56,17 @@ export function getSpaceGitStub(env: Env, agentId: string): SpaceGitExportStub |
     return ns.get(ns.idFromName(agentId)) as unknown as SpaceGitExportStub;
 }
 
+export async function resolveGitCloneRepositoryTarget(env: Env, agentId: string): Promise<GitCloneRepositoryTarget> {
+    const state = await getAgentState(env, agentId);
+    return state?.behaviorType === 'think'
+        ? { kind: 'space', spaceName: agentId }
+        : { kind: 'agent', agentId };
+}
+
 /** Whether an app uses the think behavior (repo lives in SpaceDO/Artifacts). */
 export async function isThinkApp(env: Env, agentId: string): Promise<boolean> {
     try {
-        const state = await getAgentState(env, agentId);
-        return state?.behaviorType === 'think';
+        return (await resolveGitCloneRepositoryTarget(env, agentId)).kind === 'space';
     } catch {
         return false;
     }

--- a/worker/api/controllers/appView/controller.ts
+++ b/worker/api/controllers/appView/controller.ts
@@ -2,7 +2,7 @@
 import { BaseController } from '../baseController';
 import { ApiResponse, ControllerResponse } from '../types';
 import type { RouteContext } from '../../types/route-context';
-import { getAgentStubLightweight } from '../../../agents';
+import { getAgentStubLightweight, resolveGitCloneRepositoryTarget } from '../../../agents';
 import { AppService } from '../../../database/services/AppService';
 import { 
     AppDetailsData, 
@@ -17,7 +17,10 @@ import { RateLimitService } from '../../../services/rate-limit/rateLimits';
 import { RateLimitExceededError } from 'shared/types/errors';
 import { extractRequestMetadata } from '../../../utils/authUtils';
 import { buildUserWorkerUrl, buildGitCloneUrl } from 'worker/utils/urls';
-import { JWTUtils } from '../../../utils/jwtUtils';
+import {
+    GIT_CLONE_TOKEN_TTL_SECONDS,
+    signGitCloneToken,
+} from '../../../utils/gitCloneToken';
 import {
     OWNER_PREVIEW_QUERY_PARAM,
     OWNER_PREVIEW_TOKEN_TTL_SECONDS,
@@ -217,14 +220,12 @@ export class AppViewController extends BaseController {
             }
 
             // Generate short-lived JWT (1 hour)
-            const jwtUtils = JWTUtils.getInstance(env);
-            const expiresIn = 3600; // 1 hour
-            const token = await jwtUtils.createToken({
-                sub: user.id,
-                email: user.email,
-                type: 'access' as const,
-                sessionId: 'git-clone-' + appId, // Special session for git operations
-            }, expiresIn);
+            const target = await resolveGitCloneRepositoryTarget(env, appId);
+            const expiresIn = GIT_CLONE_TOKEN_TTL_SECONDS;
+            const token = await signGitCloneToken(env, {
+                userId: user.id,
+                target,
+            });
 
             const responseData: GitCloneTokenData = {
                 token,

--- a/worker/api/handlers/git-protocol.test.ts
+++ b/worker/api/handlers/git-protocol.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitCloneRepositoryTarget } from '../../utils/gitCloneToken';
+
+interface MockApp {
+	id: string;
+	userId: string;
+	visibility: 'public' | 'private';
+	createdAt: Date;
+}
+
+const APP_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const APP_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const APP_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const apps = new Map<string, MockApp>();
+const targets = new Map<string, GitCloneRepositoryTarget>();
+const exportSpaceGitObjects = vi.fn(async (_spaceName: string) => []);
+const exportAgentGitObjects = vi.fn(async (_agentId: string) => ({
+	gitObjects: [],
+	query: '',
+	hasCommits: false,
+	templateDetails: null,
+}));
+
+vi.mock('../../database/services/AppService', () => ({
+	AppService: class {
+		async getAppDetails(appId: string) {
+			return apps.get(appId) ?? null;
+		}
+	},
+}));
+
+vi.mock('../../agents', () => ({
+	resolveGitCloneRepositoryTarget: async (_env: unknown, appId: string) => {
+		const target = targets.get(appId);
+		if (!target) throw new Error(`Missing target for ${appId}`);
+		return target;
+	},
+	getSpaceGitStub: (_env: unknown, spaceName: string) => ({
+		exportGitObjects: () => exportSpaceGitObjects(spaceName),
+	}),
+	getAgentStub: async (_env: unknown, agentId: string) => ({
+		exportGitObjects: () => exportAgentGitObjects(agentId),
+	}),
+}));
+
+const { handleGitProtocolRequest } = await import('./git-protocol');
+const { signGitCloneToken } = await import('../../utils/gitCloneToken');
+const { JWTUtils } = await import('../../utils/jwtUtils');
+
+type HandlerEnv = Parameters<typeof handleGitProtocolRequest>[1];
+type HandlerContext = Parameters<typeof handleGitProtocolRequest>[2];
+
+const env = {
+	JWT_SECRET: 'test-secret-for-git-protocol-validation-1234567890',
+} as HandlerEnv;
+
+const ctx = {
+	waitUntil: vi.fn(),
+	passThroughOnException: vi.fn(),
+	props: {},
+} as unknown as HandlerContext;
+
+function seedApp(id: string, userId: string, target: GitCloneRepositoryTarget, visibility: 'public' | 'private' = 'private'): void {
+	apps.set(id, { id, userId, visibility, createdAt: new Date('2026-01-01T00:00:00Z') });
+	targets.set(id, target);
+}
+
+function gitRequest(appId: string, endpoint: 'info/refs' | 'git-upload-pack', token?: string): Request {
+	const headers = token ? { Authorization: `Basic ${btoa(`oauth2:${token}`)}` } : undefined;
+	return new Request(`https://example.com/apps/${appId}.git/${endpoint}`, {
+		method: endpoint === 'git-upload-pack' ? 'POST' : 'GET',
+		headers,
+	});
+}
+
+beforeEach(() => {
+	apps.clear();
+	targets.clear();
+	exportSpaceGitObjects.mockClear();
+	exportAgentGitObjects.mockClear();
+	vi.mocked(ctx.waitUntil).mockClear();
+});
+
+describe('Git protocol repository authorization', () => {
+	it('clones a Think app from its Space repository', async () => {
+		const target = { kind: 'space', spaceName: APP_A } as const;
+		seedApp(APP_A, 'user-a', target);
+		const token = await signGitCloneToken(env, { userId: 'user-a', target });
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_A, 'info/refs', token), env, ctx);
+
+		expect(response.status).toBe(200);
+		expect(exportSpaceGitObjects).toHaveBeenCalledWith(APP_A);
+		expect(exportAgentGitObjects).not.toHaveBeenCalled();
+	});
+
+	it('clones a Phasic app from its agent repository', async () => {
+		const target = { kind: 'agent', agentId: APP_A } as const;
+		seedApp(APP_A, 'user-a', target);
+		const token = await signGitCloneToken(env, { userId: 'user-a', target });
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_A, 'info/refs', token), env, ctx);
+
+		expect(response.status).toBe(200);
+		expect(exportAgentGitObjects).toHaveBeenCalledWith(APP_A);
+		expect(exportSpaceGitObjects).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['Think', { kind: 'space', spaceName: APP_A }, { kind: 'space', spaceName: APP_B }],
+		['Phasic', { kind: 'agent', agentId: APP_A }, { kind: 'agent', agentId: APP_B }],
+	] as const)('rejects same-owner cross-app reuse for %s repositories', async (_name, sourceTarget, targetTarget) => {
+		seedApp(APP_A, 'user-a', sourceTarget);
+		seedApp(APP_B, 'user-a', targetTarget);
+		const token = await signGitCloneToken(env, { userId: 'user-a', target: sourceTarget });
+
+		for (const endpoint of ['info/refs', 'git-upload-pack'] as const) {
+			const response = await handleGitProtocolRequest(gitRequest(APP_B, endpoint, token), env, ctx);
+			expect(response.status).toBe(401);
+		}
+		expect(exportSpaceGitObjects).not.toHaveBeenCalled();
+		expect(exportAgentGitObjects).not.toHaveBeenCalled();
+	});
+
+	it('rejects cross-backend token reuse', async () => {
+		const sourceTarget = { kind: 'space', spaceName: APP_A } as const;
+		seedApp(APP_A, 'user-a', sourceTarget);
+		seedApp(APP_B, 'user-a', { kind: 'agent', agentId: APP_B });
+		const token = await signGitCloneToken(env, { userId: 'user-a', target: sourceTarget });
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_B, 'info/refs', token), env, ctx);
+
+		expect(response.status).toBe(401);
+		expect(exportSpaceGitObjects).not.toHaveBeenCalled();
+		expect(exportAgentGitObjects).not.toHaveBeenCalled();
+	});
+
+	it('rejects a correctly scoped token whose user does not own the app', async () => {
+		const target = { kind: 'space', spaceName: APP_C } as const;
+		seedApp(APP_C, 'user-c', target);
+		const token = await signGitCloneToken(env, { userId: 'user-a', target });
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_C, 'info/refs', token), env, ctx);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('rejects generic access tokens', async () => {
+		const target = { kind: 'agent', agentId: APP_A } as const;
+		seedApp(APP_A, 'user-a', target);
+		const token = await JWTUtils.getInstance(env).createToken({
+			sub: 'user-a',
+			email: 'user@example.com',
+			type: 'access',
+			sessionId: `git-clone-${APP_A}`,
+		});
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_A, 'info/refs', token), env, ctx);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('rejects malformed Basic auth headers with 401 instead of 500', async () => {
+		seedApp(APP_A, 'user-a', { kind: 'agent', agentId: APP_A });
+
+		const response = await handleGitProtocolRequest(
+			new Request(`https://example.com/apps/${APP_A}.git/info/refs`, {
+				headers: { Authorization: 'Basic %%%not-base64%%%' },
+			}),
+			env,
+			ctx,
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('allows public repositories without a token', async () => {
+		seedApp(APP_A, 'user-a', { kind: 'space', spaceName: APP_A }, 'public');
+
+		const response = await handleGitProtocolRequest(gitRequest(APP_A, 'info/refs'), env, ctx);
+
+		expect(response.status).toBe(200);
+		expect(exportSpaceGitObjects).toHaveBeenCalledWith(APP_A);
+	});
+});

--- a/worker/api/handlers/git-protocol.ts
+++ b/worker/api/handlers/git-protocol.ts
@@ -5,13 +5,13 @@
  * 
  * Architecture: Export git objects from DO, build repo in worker to save DO memory
  */
-import { getAgentStub, getSpaceGitStub, isThinkApp } from '../../agents';
+import { getAgentStub, getSpaceGitStub, resolveGitCloneRepositoryTarget } from '../../agents';
 import { createLogger } from '../../logger';
 import { GitCloneService } from '../../agents/git/git-clone-service';
 import type { MemFS } from '../../agents/git/memfs';
 import type { TemplateDetails } from '../../services/sandbox/sandboxTypes';
 import { AppService } from '../../database/services/AppService';
-import { JWTUtils } from '../../utils/jwtUtils';
+import { verifyGitCloneToken, type GitCloneRepositoryTarget } from '../../utils/gitCloneToken';
 import { GitCache } from './git-cache';
 
 const logger = createLogger('GitProtocol');
@@ -21,7 +21,7 @@ interface ResolvedGitObjects {
     query: string;
     hasCommits: boolean;
     templateDetails: TemplateDetails | null;
-    isThink: boolean;
+    target: GitCloneRepositoryTarget;
 }
 
 /**
@@ -29,20 +29,20 @@ interface ResolvedGitObjects {
  * SpaceDO/Artifacts (exported verbatim); other apps use the agent's own git
  * (rebased on the template).
  */
-async function resolveGitObjectsForApp(env: Env, appId: string): Promise<ResolvedGitObjects> {
-    if (await isThinkApp(env, appId)) {
-        const spaceStub = getSpaceGitStub(env, appId);
+async function resolveGitObjectsForTarget(env: Env, target: GitCloneRepositoryTarget): Promise<ResolvedGitObjects> {
+    if (target.kind === 'space') {
+        const spaceStub = getSpaceGitStub(env, target.spaceName);
         const gitObjects = spaceStub ? await spaceStub.exportGitObjects() : [];
-        return { gitObjects, query: '', hasCommits: gitObjects.length > 0, templateDetails: null, isThink: true };
+        return { gitObjects, query: '', hasCommits: gitObjects.length > 0, templateDetails: null, target };
     }
-    const agentStub = await getAgentStub(env, appId);
+    const agentStub = await getAgentStub(env, target.agentId);
     const exported = await agentStub.exportGitObjects();
-    return { ...exported, isThink: false };
+    return { ...exported, target };
 }
 
 /** Build the in-memory repo, verbatim for think apps and template-rebased otherwise. */
 async function buildRepoFor(resolved: ResolvedGitObjects, appQuery: string, appCreatedAt?: Date): Promise<MemFS> {
-    return resolved.isThink
+    return resolved.target.kind === 'space'
         ? GitCloneService.buildRepositoryFromObjects(resolved.gitObjects)
         : GitCloneService.buildRepository({
               gitObjects: resolved.gitObjects,
@@ -99,11 +99,15 @@ function extractAgentHeadOid(gitObjects: Array<{ path: string; data: Uint8Array 
 /**
  * Verify git access (public apps or owner with valid token)
  */
+type GitAccessResult =
+    | { hasAccess: false }
+    | { hasAccess: true; target: GitCloneRepositoryTarget; appCreatedAt?: Date };
+
 async function verifyGitAccess(
     request: Request,
     env: Env,
     appId: string
-): Promise<{ hasAccess: boolean; appCreatedAt?: Date }> {
+): Promise<GitAccessResult> {
     logger.info('Verifying git access', { appId });
     
     const appService = new AppService(env);
@@ -116,9 +120,11 @@ async function verifyGitAccess(
         return { hasAccess: false };
     }
 
+    const target = await resolveGitCloneRepositoryTarget(env, appId);
+
     // Public apps: anyone can clone
     if (app.visibility === 'public') {
-        return { hasAccess: true, appCreatedAt: app.createdAt || undefined };
+        return { hasAccess: true, target, appCreatedAt: app.createdAt || undefined };
     }
 
     // Private apps: require authentication
@@ -132,10 +138,14 @@ async function verifyGitAccess(
         logger.info('Extracted Bearer token', { tokenLength: token.length });
     } else if (authHeader?.startsWith('Basic ')) {
         // Git sends credentials as Basic auth
-        const decoded = atob(authHeader.slice(6));
-        const [username, password] = decoded.split(':');
-        token = password || username;
-        logger.info('Extracted Basic auth token', { tokenLength: token?.length, hasUsername: !!username, hasPassword: !!password });
+        try {
+            const decoded = atob(authHeader.slice(6));
+            const [username, password] = decoded.split(':');
+            token = password || username;
+            logger.info('Extracted Basic auth token', { tokenLength: token?.length, hasUsername: !!username, hasPassword: !!password });
+        } catch {
+            logger.warn('Malformed Basic auth header - will return 401 to prompt git for credentials');
+        }
     }
 
     if (!token) {
@@ -143,27 +153,25 @@ async function verifyGitAccess(
         return { hasAccess: false };
     }
 
-    // Verify token using JWTUtils
-    const jwtUtils = JWTUtils.getInstance(env);
-    const payload = await jwtUtils.verifyToken(token);
+    const claims = await verifyGitCloneToken(env, token, target);
 
-    if (!payload) {
-        logger.warn('Token verification failed - invalid or expired token');
+    if (!claims) {
+        logger.warn('Token verification failed - invalid, expired, or scoped to another repository');
         return { hasAccess: false };
     }
 
-    logger.info('Token verified', { userId: payload.sub, appOwnerId: app.userId });
+    logger.info('Token verified', { userId: claims.userId, appOwnerId: app.userId, repositoryKind: target.kind });
 
     // Check if user owns the app
-    const hasAccess = payload.sub === app.userId;
+    const hasAccess = claims.userId === app.userId;
     
     if (!hasAccess) {
-        logger.warn('Access denied - user does not own this app', { userId: payload.sub, appOwnerId: app.userId });
-    } else {
-        logger.info('Access granted - user owns this app');
+        logger.warn('Access denied - user does not own this app', { userId: claims.userId, appOwnerId: app.userId });
+        return { hasAccess: false };
     }
-    
-    return { hasAccess, appCreatedAt: hasAccess ? (app.createdAt || undefined) : undefined };
+
+    logger.info('Access granted - user owns this app');
+    return { hasAccess: true, target, appCreatedAt: app.createdAt || undefined };
 }
 
 /**
@@ -177,8 +185,8 @@ async function handleInfoRefs(
 ): Promise<Response> {
     try {
         // Verify access first
-        const { hasAccess, appCreatedAt } = await verifyGitAccess(request, env, appId);
-        if (!hasAccess) {
+        const access = await verifyGitAccess(request, env, appId);
+        if (!access.hasAccess) {
             // Return 401 with WWW-Authenticate to prompt git for credentials
             return new Response('Authentication required', { 
                 status: 401,
@@ -188,7 +196,8 @@ async function handleInfoRefs(
             });
         }
         
-        const resolved = await resolveGitObjectsForApp(env, appId);
+        const { appCreatedAt, target } = access;
+        const resolved = await resolveGitObjectsForTarget(env, target);
         const { gitObjects, query, hasCommits, templateDetails } = resolved;
         
         if (!hasCommits) {
@@ -265,8 +274,8 @@ async function handleUploadPack(
 ): Promise<Response> {
     try {
         // Verify access first
-        const { hasAccess, appCreatedAt } = await verifyGitAccess(request, env, appId);
-        if (!hasAccess) {
+        const access = await verifyGitAccess(request, env, appId);
+        if (!access.hasAccess) {
             // Return 401 with WWW-Authenticate to prompt git for credentials
             return new Response('Authentication required', { 
                 status: 401,
@@ -276,7 +285,8 @@ async function handleUploadPack(
             });
         }
         
-        const resolved = await resolveGitObjectsForApp(env, appId);
+        const { appCreatedAt, target } = access;
+        const resolved = await resolveGitObjectsForTarget(env, target);
         const { gitObjects, query, hasCommits, templateDetails } = resolved;
         
         if (!hasCommits) {

--- a/worker/utils/gitCloneToken.test.ts
+++ b/worker/utils/gitCloneToken.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+	GIT_CLONE_TOKEN_TTL_SECONDS,
+	signGitCloneToken,
+	verifyGitCloneToken,
+	type GitCloneRepositoryTarget,
+} from './gitCloneToken';
+import { JWTUtils } from './jwtUtils';
+
+const testEnv = {
+	JWT_SECRET: 'test-secret-for-git-clone-token-validation-1234567890',
+};
+
+const spaceTarget: GitCloneRepositoryTarget = { kind: 'space', spaceName: 'app-a' };
+const agentTarget: GitCloneRepositoryTarget = { kind: 'agent', agentId: 'app-a' };
+
+describe('gitCloneToken', () => {
+	it.each([
+		['Space', spaceTarget],
+		['agent', agentTarget],
+	] as const)('verifies a valid %s repository token', async (_name, target) => {
+		const token = await signGitCloneToken(testEnv, { userId: 'user-a', target });
+
+		expect(await verifyGitCloneToken(testEnv, token, target)).toEqual({
+			userId: 'user-a',
+			target,
+		});
+	});
+
+	it('rejects same-owner reuse against another Space or agent repository', async () => {
+		const spaceToken = await signGitCloneToken(testEnv, { userId: 'user-a', target: spaceTarget });
+		const agentToken = await signGitCloneToken(testEnv, { userId: 'user-a', target: agentTarget });
+
+		await expect(verifyGitCloneToken(testEnv, spaceToken, { kind: 'space', spaceName: 'app-b' })).resolves.toBeNull();
+		await expect(verifyGitCloneToken(testEnv, agentToken, { kind: 'agent', agentId: 'app-b' })).resolves.toBeNull();
+	});
+
+	it('rejects repository-kind confusion for the same identifier', async () => {
+		const token = await signGitCloneToken(testEnv, { userId: 'user-a', target: spaceTarget });
+
+		await expect(verifyGitCloneToken(testEnv, token, agentTarget)).resolves.toBeNull();
+	});
+
+	it('rejects malformed claims and the wrong purpose', async () => {
+		const jwt = JWTUtils.getInstance(testEnv);
+		const wrongPurpose = await jwt.signPayload(
+			{ purpose: 'space_preview', userId: 'user-a', target: spaceTarget },
+			GIT_CLONE_TOKEN_TTL_SECONDS,
+		);
+		const malformed = await jwt.signPayload(
+			{ purpose: 'git_clone', userId: '', target: { kind: 'space', spaceName: '' } },
+			GIT_CLONE_TOKEN_TTL_SECONDS,
+		);
+
+		await expect(verifyGitCloneToken(testEnv, wrongPurpose, spaceTarget)).resolves.toBeNull();
+		await expect(verifyGitCloneToken(testEnv, malformed, spaceTarget)).resolves.toBeNull();
+	});
+
+	it('rejects expired tokens', async () => {
+		const jwt = JWTUtils.getInstance(testEnv);
+		const token = await jwt.signPayload(
+			{ purpose: 'git_clone', userId: 'user-a', target: spaceTarget },
+			-1,
+		);
+
+		await expect(verifyGitCloneToken(testEnv, token, spaceTarget)).resolves.toBeNull();
+	});
+
+	it('does not accept generic access tokens, including legacy git-clone sessions', async () => {
+		const jwt = JWTUtils.getInstance(testEnv);
+		const token = await jwt.createToken({
+			sub: 'user-a',
+			email: 'user@example.com',
+			type: 'access',
+			sessionId: 'git-clone-app-a',
+		});
+
+		await expect(verifyGitCloneToken(testEnv, token, agentTarget)).resolves.toBeNull();
+	});
+
+	it('cannot be parsed as a normal API access token', async () => {
+		const token = await signGitCloneToken(testEnv, { userId: 'user-a', target: agentTarget });
+
+		await expect(JWTUtils.getInstance(testEnv).verifyToken(token)).resolves.toBeNull();
+	});
+
+	it('does not copy access-token fields from a widened claims object', async () => {
+		const claims = {
+			userId: 'user-a',
+			target: agentTarget,
+			sub: 'user-a',
+			email: 'user@example.com',
+			type: 'access' as const,
+			sessionId: 'session-a',
+		};
+		const token = await signGitCloneToken(testEnv, claims);
+		const payload = await JWTUtils.getInstance(testEnv).verifyPayload(token);
+
+		expect(payload).not.toHaveProperty('sub');
+		expect(payload).not.toHaveProperty('email');
+		expect(payload).not.toHaveProperty('type');
+		expect(payload).not.toHaveProperty('sessionId');
+		await expect(JWTUtils.getInstance(testEnv).verifyToken(token)).resolves.toBeNull();
+	});
+});

--- a/worker/utils/gitCloneToken.ts
+++ b/worker/utils/gitCloneToken.ts
@@ -1,0 +1,59 @@
+import { JWTUtils } from './jwtUtils';
+
+const GIT_CLONE_PURPOSE = 'git_clone';
+export const GIT_CLONE_TOKEN_TTL_SECONDS = 60 * 60;
+
+export type GitCloneRepositoryTarget =
+	| { kind: 'space'; spaceName: string }
+	| { kind: 'agent'; agentId: string };
+
+export interface GitCloneTokenClaims {
+	userId: string;
+	target: GitCloneRepositoryTarget;
+}
+
+export async function signGitCloneToken(
+	env: { JWT_SECRET: string },
+	claims: GitCloneTokenClaims,
+): Promise<string> {
+	const jwt = JWTUtils.getInstance(env);
+	return jwt.signPayload(
+		{ purpose: GIT_CLONE_PURPOSE, userId: claims.userId, target: claims.target },
+		GIT_CLONE_TOKEN_TTL_SECONDS,
+	);
+}
+
+function parseTarget(value: unknown): GitCloneRepositoryTarget | null {
+	if (!value || typeof value !== 'object') return null;
+	const target = value as Record<string, unknown>;
+	if (target.kind === 'space' && typeof target.spaceName === 'string' && target.spaceName.trim() !== '') {
+		return { kind: 'space', spaceName: target.spaceName };
+	}
+	if (target.kind === 'agent' && typeof target.agentId === 'string' && target.agentId.trim() !== '') {
+		return { kind: 'agent', agentId: target.agentId };
+	}
+	return null;
+}
+
+function targetsMatch(actual: GitCloneRepositoryTarget, expected: GitCloneRepositoryTarget): boolean {
+	if (actual.kind === 'space') {
+		return expected.kind === 'space' && actual.spaceName === expected.spaceName;
+	}
+	return expected.kind === 'agent' && actual.agentId === expected.agentId;
+}
+
+export async function verifyGitCloneToken(
+	env: { JWT_SECRET: string },
+	token: string,
+	expectedTarget: GitCloneRepositoryTarget,
+): Promise<GitCloneTokenClaims | null> {
+	const jwt = JWTUtils.getInstance(env);
+	const payload = await jwt.verifyPayload(token);
+	if (!payload || payload.purpose !== GIT_CLONE_PURPOSE) return null;
+	if (typeof payload.userId !== 'string' || payload.userId.trim() === '') return null;
+
+	const target = parseTarget(payload.target);
+	if (!target || !targetsMatch(target, expectedTarget)) return null;
+
+	return { userId: payload.userId, target };
+}


### PR DESCRIPTION
## Summary
- Git clone tokens were minted as ordinary access JWTs and verified only by checking that the token subject owned the requested app; the app-specific sessionId claim was never checked at verification time, so a token minted for one private app could clone any other private app owned by the same user.
- Replace the token shape with a dedicated, purpose-scoped credential (worker/utils/gitCloneToken.ts) bound to { userId, target }, where target discriminates between a Think app Space repository and an agent-managed repository.
- Both git smart-HTTP endpoints (info/refs, git-upload-pack) now require an exact target match in addition to current ownership before serving repository data.
- The new token can no longer be parsed as a normal API access token (JWTUtils.verifyToken() rejects it).
- Malformed Basic auth headers now return 401 instead of an uncaught atob() exception surfacing as 500.

## Files changed
- worker/utils/gitCloneToken.ts (new) - git-only JWT claims/signer/verifier
- worker/agents/index.ts - shared resolver mapping an app id to its repository target, reused by minting and verification
- worker/api/controllers/appView/controller.ts - mint tokens scoped to the resolved target
- worker/api/handlers/git-protocol.ts - verify target + ownership before serving repository data; fix malformed Basic-auth handling
- worker/utils/gitCloneToken.test.ts, worker/api/handlers/git-protocol.test.ts (new) - regression coverage

#### Test plan
- [x] bunx vitest run worker/utils/gitCloneToken.test.ts worker/api/handlers/git-protocol.test.ts (18/18 passing)
- [x] bun run typecheck
- [x] bun run lint
- [x] bun run build
- [x] Manual review of same-owner cross-app reuse, cross-backend confusion, cross-owner tokens, generic-token rejection, and malformed auth header handling
