### PR TITLE
fix(discover): refine loading state and app actions

### DIFF
--- a/src/components/shared/AppCard.tsx
+++ b/src/components/shared/AppCard.tsx
@@ -437,14 +437,12 @@ export const AppCard = React.memo<AppCardProps>(
 									src={app.screenshotUrl}
 									alt={`${app.title} preview`}
 									className={cn(
-										'h-full w-full object-cover object-center',
-										'scale-[1.01] duration-500 ease-out group-hover:scale-[1.05]',
+										'size-full object-cover',
+										'scale-100 transition-transform duration-200 ease-out group-hover:scale-105',
 										'bg-kumo-tint',
 									)}
 									loading="lazy"
 									fetchPriority="low"
-									sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-									srcSet={`${app.screenshotUrl} 1x, ${app.screenshotUrl} 1.5x, ${app.screenshotUrl} 2x, ${app.screenshotUrl} 3x`}
 									decoding="async"
 									onError={(e) => {
 										const target = e.target as HTMLImageElement;
@@ -460,14 +458,6 @@ export const AppCard = React.memo<AppCardProps>(
 												placeholder.style.opacity = '1';
 											}
 										}, 150);
-									}}
-									onLoad={(e) => {
-										const target = e.target as HTMLImageElement;
-										target.style.opacity = '1';
-									}}
-									style={{
-										opacity: 0,
-										transition: 'opacity 0.35s ease-out, transform 0.5s ease-out',
 									}}
 								/>
 							) : null}

--- a/src/components/shared/AppListContainer.tsx
+++ b/src/components/shared/AppListContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2, RefreshCw, X, Code2 } from 'lucide-react';
-import { SkeletonLine } from '@cloudflare/kumo';
+import { Loader, SkeletonLine } from '@cloudflare/kumo';
 import { Button } from '@/components/ui/button';
 import { AppCard } from './AppCard';
 import type { AppListData } from '@/hooks/use-paginated-apps';
@@ -168,7 +168,7 @@ export const AppListContainer: React.FC<AppListContainerProps> = ({
 	if (loading) {
 		return (
 			<div className={className}>
-				<AppCardSkeletonGrid count={8} showUser={showUser} />
+				<AppCardSkeletonGrid count={6} showUser={showUser} />
 			</div>
 		);
 	}
@@ -234,19 +234,19 @@ export const AppListContainer: React.FC<AppListContainerProps> = ({
 			{infiniteScroll && hasMore && (
 				<div
 					ref={triggerRef}
-					className="relative mt-8"
-					style={{ height: loadingMore ? 'auto' : '80px' }}
+					className="flex min-h-20 items-center justify-center"
+					aria-live="polite"
+					aria-busy={loadingMore}
 				>
 					{loadingMore && (
 						<motion.div
 							initial={{ opacity: 0 }}
 							animate={{ opacity: 1 }}
-							transition={{ duration: 0.3 }}
+							transition={{ duration: 0.2 }}
+							className="flex items-center gap-2 text-kumo-subtle"
 						>
-							<AppCardSkeletonGrid
-								count={4}
-								showUser={showUser}
-							/>
+							<Loader size="sm" />
+							<span className="text-sm">Loading more apps...</span>
 						</motion.div>
 					)}
 				</div>


### PR DESCRIPTION
- Keep the initial Discover skeleton grid aligned by rendering a full 3-column set.
- Replace infinite-scroll skeleton cards with a compact loader row so loading more does not leave blank grid cells.
- Tighten app card image transitions and hide owner-only app actions behind signed-in state.
