### PR TITLE
fix(think): pass queued image attachments into Agent mode chat turns

### DIFF
--- a/worker/agents/core/behaviors/think.ts
+++ b/worker/agents/core/behaviors/think.ts
@@ -40,7 +40,7 @@ import type { CloudflareDeploymentErrorCode } from '../../../api/websocketTypes'
  */
 type ThinkAgentStub = {
 	configureVibe: (config: ThinkAgentConfig) => Promise<void>;
-	chat: (userMessage: string, callback: RpcTarget) => Promise<void>;
+	chat: (userMessage: string | UIMessage, callback: RpcTarget) => Promise<void>;
 	getMessages: () => Promise<UIMessage[]>;
 	clearMessages: () => Promise<void>;
 };
@@ -471,9 +471,19 @@ export class ThinkCodingBehavior
 			const pending = this.state.pendingUserInputs.slice();
 			this.setState({ ...this.state, pendingUserInputs: [] });
 
+			// Images are queued out-of-band in `pendingUserImages` (see
+			// `BaseCodingBehavior.queueUserRequest`) rather than in durable
+			// state; drain them alongside the text so attachments from
+			// `user_suggestion` messages actually reach the model instead of
+			// being silently dropped.
+			const pendingImages = this.pendingUserImages;
+			if (pendingImages.length > 0) {
+				this.pendingUserImages = [];
+			}
+
 			const compiled = pending.join('\n');
 			try {
-				await this.runPrompt(compiled);
+				await this.runPrompt(compiled, pendingImages.length > 0 ? pendingImages : undefined);
 			} catch (e) {
 				this.logger.error('Think prompt failed', e);
 				this.broadcast(WebSocketMessageResponses.ERROR, {
@@ -496,7 +506,7 @@ export class ThinkCodingBehavior
 	 * Submit a prompt to the ThinkAgent and translate its streamed
 	 * `UIMessageChunk`s into VibeSDK WebSocket events.
 	 */
-	private async runPrompt(text: string): Promise<void> {
+	private async runPrompt(text: string, images?: ProcessedImageAttachment[]): Promise<void> {
 		const conversationId = IdGenerator.generateConversationId();
 		this.broadcast(WebSocketMessageResponses.CONVERSATION_RESPONSE, {
 			message: '',
@@ -523,8 +533,22 @@ export class ThinkCodingBehavior
 		);
 
 		const stub = await this.getThinkStub();
+		const userMessage: string | UIMessage = images && images.length > 0
+			? {
+				id: generateNanoId(),
+				role: 'user',
+				parts: [
+					{ type: 'text', text },
+					...images.map((image) => ({
+						type: 'file' as const,
+						mediaType: image.mimeType,
+						url: `data:${image.mimeType};base64,${image.base64Data}`,
+					})),
+				],
+			}
+			: text;
 		try {
-			await stub.chat(text, forwarder);
+			await stub.chat(userMessage, forwarder);
 		} finally {
 			this.broadcast(WebSocketMessageResponses.USAGE_UPDATED, {
 				message: 'Usage data updated',


### PR DESCRIPTION
## Summary

Fixes #392 (and the recurrence of #154 — same root cause, just surfaced in what the app now calls Agent mode).

Image/screenshot attachments sent during an active Agent-mode (Think) conversation were silently dropped. They'd get uploaded to R2, but never reached the model.

## Root cause

`ThinkCodingBehavior.handleUserInput` queues attachments into `this.pendingUserImages` via `queueUserRequest()` — the same in-memory mechanism Phasic mode already relies on. But `ThinkCodingBehavior.build()` only drained the text queue (`pendingUserInputs`) and called `runPrompt()` with a bare string, so `pendingUserImages` was written but never read anywhere in `think.ts`. Every attachment after upload was discarded.

Separately, `runPrompt()` always forwarded a plain string to `ThinkAgent.chat(text, forwarder)`, even though `chat()` accepts `string | UIMessage` and already supports multimodal file parts — Agent mode just never used that path.

## Fix

- `build()` now drains `pendingUserImages` alongside the text queue on each loop iteration (mirroring how Phasic mode consumes the same field) and clears it after reading.
- `runPrompt()` takes an optional `images` param; when present it builds a `UIMessage` (`{ id, role: 'user', parts: [text part, ...file parts] }`) with each image as a `data:` URL, instead of always sending plain text.
- Updated the local `ThinkAgentStub` RPC type to reflect `chat`'s real `string | UIMessage` signature.

## Test plan

- Confirmed via an isolated TypeScript check against the actual `ai` / `@cloudflare/think` package type declarations (pulled with `npm pack`, since installing the full workspace wasn't feasible in the sandbox this was authored in) that the constructed `UIMessage` object satisfies `UIMessage`/`FileUIPart` under `strict: true`.
- Full-file syntax check via the TypeScript compiler API.
- Manual code trace confirming `this.behavior` (and therefore `pendingUserImages`) is the same in-memory instance across `handleUserInput` and the subsequent `generateAllFiles()` → `build()` call, so images queued mid-turn are picked up on the next loop iteration.
- [ ] Manual repro in a live environment: attach an image in Agent mode after the first message and confirm the model receives it (I don't have a deployed environment to verify against; would appreciate a maintainer smoke test).